### PR TITLE
Update --input flag to --input-file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ go build .
 Generate Go structs from the OSCAL JSON schema:
 
 ```bash
-./go-oscal --input test/oscal_component_schema.json \
+./go-oscal --input-file test/oscal_component_schema.json \
            --output-file internal/oscal/types.go \
            --sub-struct \
-           --pkg oscal
+           --pkg oscal \
+           --tags json,yaml
 ```
 
 After running the above command, the auto-generated Go structs are output to a file at `internal/oscal/types.go`


### PR DESCRIPTION
The flag changed from `--input` to `--input-file` in an attempt to be more precise about what the flag expects as input.

This change wasn't reflected in the README usage example/section after updating it

It also adds the `--tags` flag since that is used to generate the existing file