### PR TITLE
Add header comment to generated structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ To view the available CLI flags and their use-case:
 
 ## Development
 
-***Note***: The unit tests are not in a passing state currently. There is an [issue](https://github.com/defenseunicorns/go-oscal/issues/9) to address this
-
 For development, the `Makefile` can be used to build, test, and generate the Go structs:
 
 ```bash

--- a/internal/oscal/generate.go
+++ b/internal/oscal/generate.go
@@ -19,6 +19,7 @@ const headerComment string = `/*
 	To regenerate: go-oscal --input-file <path_to_oscal_json_schema_file> \
 							--output-file <name_of_go_types_file> // the path to this file must already exist \
 							--tags json,yaml // the tags to add to the Go structs
+							--pkg <name_of_your_go_package> // defaults to "main"
 
 	For more information on how to use go-oscal: go-oscal --help
 

--- a/internal/oscal/generate.go
+++ b/internal/oscal/generate.go
@@ -21,7 +21,7 @@ const headerComment string = `/*
 	go-oscal \
 		--input-file <path_to_oscal_json_schema_file> \
 		--output-file <name_of_go_types_file> // the path to this file must already exist \
-		--tags json,yaml // the tags to add to the Go structs
+		--tags json,yaml // the tags to add to the Go structs \
 		--pkg <name_of_your_go_package> // defaults to "main"
 
 	For more information on how to use go-oscal: go-oscal --help

--- a/internal/oscal/generate.go
+++ b/internal/oscal/generate.go
@@ -13,6 +13,18 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const headerComment string = `/*
+	This file was auto-generated with go-oscal.
+
+	To regenerate: go-oscal --input-file <path_to_oscal_json_schema_file> \
+							--output-file <name_of_go_types_file> // the path to this file must already exist \
+							--tags json,yaml // the tags to add to the Go structs
+
+	For more information on how to use go-oscal: go-oscal --help
+
+	Source: https://github.com/defenseunicorns/go-oscal
+	*/`
+
 // commonInitialisms is a set of common initialisms.
 // Only add entries that are highly unlikely to be non-initialisms.
 // For instance, "ID" is fine (Freudian code is rare), but "AND" is not.
@@ -278,7 +290,7 @@ func generateModelTypes(obj map[string]interface{}, structId string, structName 
 
 func generateStruct(structMap map[string][]string, pkgName string) string {
 	existing := make(map[string]bool)
-	typesString := fmt.Sprintf("package %s\n", pkgName)
+	typesString := fmt.Sprintf("%s\n\n package %s\n", headerComment, pkgName)
 	// Begin generation of struct
 	for i, v := range structMap {
 
@@ -296,7 +308,7 @@ func generateStruct(structMap map[string][]string, pkgName string) string {
 				typesString += fmt.Sprintf("\n\t%s", value)
 			}
 		}
-		typesString += fmt.Sprintf("\n}")
+		typesString += fmt.Sprintf("\n}\n")
 	}
 	return typesString
 }

--- a/internal/oscal/generate.go
+++ b/internal/oscal/generate.go
@@ -18,10 +18,11 @@ const headerComment string = `/*
 
 	To regenerate:
 	
-	go-oscal --input-file <path_to_oscal_json_schema_file> \
-			 --output-file <name_of_go_types_file> // the path to this file must already exist \
-			 --tags json,yaml // the tags to add to the Go structs
-			 --pkg <name_of_your_go_package> // defaults to "main"
+	go-oscal \
+		--input-file <path_to_oscal_json_schema_file> \
+		--output-file <name_of_go_types_file> // the path to this file must already exist \
+		--tags json,yaml // the tags to add to the Go structs
+		--pkg <name_of_your_go_package> // defaults to "main"
 
 	For more information on how to use go-oscal: go-oscal --help
 

--- a/internal/oscal/generate.go
+++ b/internal/oscal/generate.go
@@ -16,10 +16,12 @@ import (
 const headerComment string = `/*
 	This file was auto-generated with go-oscal.
 
-	To regenerate: go-oscal --input-file <path_to_oscal_json_schema_file> \
-							--output-file <name_of_go_types_file> // the path to this file must already exist \
-							--tags json,yaml // the tags to add to the Go structs
-							--pkg <name_of_your_go_package> // defaults to "main"
+	To regenerate:
+	
+	go-oscal --input-file <path_to_oscal_json_schema_file> \
+			 --output-file <name_of_go_types_file> // the path to this file must already exist \
+			 --tags json,yaml // the tags to add to the Go structs
+			 --pkg <name_of_your_go_package> // defaults to "main"
 
 	For more information on how to use go-oscal: go-oscal --help
 


### PR DESCRIPTION
Closes https://github.com/defenseunicorns/go-oscal/issues/8

- Add header comment to generated structs that describes how it was generated
- Add spacing between generated structs
- Remove note about failing tests in README