### PR TITLE
Feat: generate command migration & convert command initial commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ $(BINDIR)/$(BINNAME): $(SRC)
 
 .PHONY: generate-compdef-stdout
 generate-compdef-stdout: clean build ## Generate Go structs from OSCAL component-definition JSON schema and outputs to stdout.
-	$(BINDIR)/$(BINNAME) -f $(OSCAL_COMPONENT_SCHEMA_FILE) --pkg componentDefinition --tags json,yaml
+	$(BINDIR)/$(BINNAME) generate -f $(OSCAL_COMPONENT_SCHEMA_FILE) --pkg componentDefinition --tags json,yaml
 
 .PHONY: generate-ssp-stdout
 generate-ssp-stdout: clean build ## Generate Go structs from OSCAL system-security-plan JSON schema and outputs to stdout.
-	$(BINDIR)/$(BINNAME) -f $(OSCAL_SSP_SCHEMA_FILE) --pkg ssp --tags json,yaml
+	$(BINDIR)/$(BINNAME) generate -f $(OSCAL_SSP_SCHEMA_FILE) --pkg ssp --tags json,yaml
 
 .PHONY: test
 test: build ## Run automated tests.
@@ -87,8 +87,8 @@ install: ## Install binary to $INSTALL_PATH.
 
 .PHONY: generate-latest-compdef
 generate-latest-compdef: clean build
-	$(BINDIR)/$(BINNAME) -f $(OSCAL_COMPONENT_SCHEMA_FILE) --pkg compdeftypes --tags json,yaml -o src/types/oscal-1-1-1/component-definition/types.go
+	$(BINDIR)/$(BINNAME) generate -f $(OSCAL_COMPONENT_SCHEMA_FILE) --pkg compdeftypes --tags json,yaml -o src/types/oscal-1-1-1/component-definition/types.go
 
 .PHONY: generate-latest-ssp
 generate-latest-ssp: clean build
-	$(BINDIR)/$(BINNAME) -f $(OSCAL_SSP_SCHEMA_FILE) --pkg ssptypes --tags json,yaml -o src/types/oscal-1-1-1/system-security-plan/types.go
+	$(BINDIR)/$(BINNAME) generate -f $(OSCAL_SSP_SCHEMA_FILE) --pkg ssptypes --tags json,yaml -o src/types/oscal-1-1-1/system-security-plan/types.go

--- a/docs/conversion/component-definition/comp-def-1-1-0.md
+++ b/docs/conversion/component-definition/comp-def-1-1-0.md
@@ -1,0 +1,20 @@
+# OSCAL Component Definition 1.1.0
+
+## Changelog
+```
+SSP: Change certain elements from required to optional for non-RMF use cases.
+SSP: improve constraints of links for cross-referencing components and indicating where components were imported from.
+POAM: add related-findings assembly.
+Profile: Remove with-parent-controls from the profile model.
+Metadata: add group attribute to props
+Metadata: add resource fragment to links (very useful for deep-linking into elements by UUID and point to sub-element UUID)
+Metadata: add actions assembly to track approvals or request for changes status.
+Metadata: correct how cross-references between controls and their parts are handled.
+⚠️ Mapping: re previous discussion, mapping, by itself or within catalog, has been moved out of the v1.1.0 release.
+```
+
+## Mapping
+- metadata `actions` field added (not required)
+- property `group` field added (not required)
+- links `resource-fragment` field added (not required)
+- Revision type -> RevisionHistoryEntry type

--- a/docs/conversion/conversion-logic.md
+++ b/docs/conversion/conversion-logic.md
@@ -1,0 +1,15 @@
+# Converting between oscal versions
+
+What goes into it?
+
+- Review Changelog
+- Review Model type Diffs
+- Identify required vs non-required fields
+
+
+## In code
+- Ingest the original model into a component definition object for its current version.
+- Create a placeholder new object?
+- Understand nuance of the upgrade
+- For newly added fields - checked required or non-required
+- Loop

--- a/src/cmd/convert/convert.go
+++ b/src/cmd/convert/convert.go
@@ -1,0 +1,34 @@
+package convert
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var ConvertCmd = &cobra.Command{
+	Use:   "convert",
+	Short: "convert existing oscal document to a newer version of oscal",
+	Long:  "Convert a given model from an older oscal version to the current (or specified) oscal version ",
+	// Example: convertHelp,
+	RunE: func(cmd *cobra.Command, componentDefinitionPaths []string) error {
+
+		// Logic here for the conversion process
+		// This should really only be the process of opening the document to a []byte and then passing it
+		// to a library that will convert it to the targeted object version.
+		// Logic here will then handle writing the output to a file or STDOUT.
+
+		return nil
+	},
+}
+
+func ConvertCommand() *cobra.Command {
+
+	// insert flag options here
+	return ConvertCmd
+}
+
+// func init() {
+// 	GenerateCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to a oscal json schema file")
+// 	GenerateCmd.Flags().StringVarP(&opts.OutputFile, "output-file", "o", "", "the name of the file to write the output to (outputs to STDOUT by default)")
+// 	GenerateCmd.Flags().StringVarP(&opts.Pkg, "pkg", "p", "main", "the name of the package for the generated code")
+// 	GenerateCmd.Flags().StringVarP(&opts.Tags, "tags", "t", "json", "comma separated list of the tags to put on the struct")
+// }

--- a/src/cmd/generate/generate.go
+++ b/src/cmd/generate/generate.go
@@ -1,0 +1,84 @@
+package generate
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/defenseunicorns/go-oscal/src/internal/oscal"
+
+	"github.com/spf13/cobra"
+)
+
+var opts = &oscal.BaseFlags{}
+
+var GenerateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "generate Golang data types from OSCAL schema",
+	Long:  "Generate Golang data types from OSCAL schema",
+	// Example: generateHelp,
+	RunE: func(cmd *cobra.Command, componentDefinitionPaths []string) error {
+		// Remove the transfer of objects across packages
+		// aggregate file IO to root
+
+		bytes, err := os.ReadFile(opts.InputFile)
+		if err != nil {
+			return err
+		}
+
+		// oscalMap, err := oscal.ParseJson(opts)
+		// if err != nil {
+		// 	return err
+		// }
+
+		tagList := formatTags()
+
+		// Generate the Go structs.
+		output, err := oscal.Generate(bytes, opts.Pkg, tagList)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error parsing", err)
+			os.Exit(1)
+		}
+		// Write the Go struct output to either stdout or a file.
+		writeOutput(output)
+		return nil
+	},
+}
+
+func GenerateCommand() *cobra.Command {
+
+	// insert flag options here
+	return GenerateCmd
+}
+
+func init() {
+	GenerateCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to a oscal json schema file")
+	GenerateCmd.Flags().StringVarP(&opts.OutputFile, "output-file", "o", "", "the name of the file to write the output to (outputs to STDOUT by default)")
+	GenerateCmd.Flags().StringVarP(&opts.Pkg, "pkg", "p", "main", "the name of the package for the generated code")
+	GenerateCmd.Flags().StringVarP(&opts.Tags, "tags", "t", "json", "comma separated list of the tags to put on the struct")
+}
+
+// formatTags formats Go struct tags.
+func formatTags() (tagList []string) {
+	if opts.Tags == "" {
+		tagList = append(tagList, "json")
+	} else {
+		tagList = strings.Split(opts.Tags, ",")
+	}
+
+	return
+}
+
+// writeOutput writes the generated Go structs to an output file
+// if provided via -o/--output-file or stdout by default.
+func writeOutput(output []byte) {
+	if opts.OutputFile != "" {
+		err := os.WriteFile(opts.OutputFile, output, 0644)
+		if err != nil {
+			log.Fatalf("writing output: %s", err)
+		}
+	} else {
+		fmt.Print(string(output))
+	}
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,17 +1,12 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
-	"os"
-	"strings"
 
-	"github.com/defenseunicorns/go-oscal/src/internal/oscal"
-
+	"github.com/defenseunicorns/go-oscal/src/cmd/convert"
+	"github.com/defenseunicorns/go-oscal/src/cmd/generate"
 	"github.com/spf13/cobra"
 )
-
-var opts = &oscal.BaseFlags{}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -19,76 +14,19 @@ var rootCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	Short: "Generate Go data types from OSCAL JSON schema",
 	Long:  "Generate Go data types from OSCAL JSON schema",
-	Run: func(cmd *cobra.Command, args []string) {
-		run()
-	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
-}
-
-func init() {
-	rootCmd.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the path to a oscal json schema file")
-	rootCmd.Flags().StringVarP(&opts.OutputFile, "output-file", "o", "", "the name of the file to write the output to (outputs to STDOUT by default)")
-	rootCmd.Flags().StringVarP(&opts.Pkg, "pkg", "p", "main", "the name of the package for the generated code")
-	rootCmd.Flags().StringVarP(&opts.Tags, "tags", "t", "json", "comma separated list of the tags to put on the struct")
-}
-
-func run() error {
-
-	// Remove the transfer of objects across packages
-	// aggregate file IO to root
-
-	bytes, err := os.ReadFile(opts.InputFile)
-	if err != nil {
-		return err
+	commands := []*cobra.Command{
+		generate.GenerateCommand(),
+		convert.ConvertCommand(),
 	}
 
-	// oscalMap, err := oscal.ParseJson(opts)
-	// if err != nil {
-	// 	return err
-	// }
+	rootCmd.AddCommand(commands...)
 
-	tagList := formatTags()
-
-	// Generate the Go structs.
-	output, err := oscal.Generate(bytes, opts.Pkg, tagList)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error parsing", err)
-		os.Exit(1)
-	}
-	// Write the Go struct output to either stdout or a file.
-	writeOutput(output)
-
-	return nil
-}
-
-// formatTags formats Go struct tags.
-func formatTags() (tagList []string) {
-	if opts.Tags == "" {
-		tagList = append(tagList, "json")
-	} else {
-		tagList = strings.Split(opts.Tags, ",")
-	}
-
-	return
-}
-
-// writeOutput writes the generated Go structs to an output file
-// if provided via -o/--output-file or stdout by default.
-func writeOutput(output []byte) {
-	if opts.OutputFile != "" {
-		err := os.WriteFile(opts.OutputFile, output, 0644)
-		if err != nil {
-			log.Fatalf("writing output: %s", err)
-		}
-	} else {
-		fmt.Print(string(output))
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/src/types/oscal-1-0-4/component-definition/types.go
+++ b/src/types/oscal-1-0-4/component-definition/types.go
@@ -1,0 +1,276 @@
+/*
+	This file was auto-generated with go-oscal.
+
+	To regenerate:
+
+	go-oscal \
+		--input-file <path_to_oscal_json_schema_file> \
+		--output-file <name_of_go_types_file> // the path to this file must already exist \
+		--tags json,yaml // the tags to add to the Go structs \
+		--pkg <name_of_your_go_package> // defaults to "main"
+
+	For more information on how to use go-oscal: go-oscal --help
+
+	Source: https://github.com/defenseunicorns/go-oscal
+*/
+
+package compdeftypes
+
+type OscalComponentDefinitionModel struct {
+	ComponentDefinition ComponentDefinition `json:"component-definition" yaml:"component-definition"`
+}
+
+type Capability struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	IncorporatesComponents []IncorporatesComponent `json:"incorporates-components,omitempty" yaml:"incorporates-components,omitempty"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Name                   string                  `json:"name" yaml:"name"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ComponentDefinition struct {
+	BackMatter                 BackMatter                  `json:"back-matter,omitempty" yaml:"back-matter,omitempty"`
+	Capabilities               []Capability                `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	Components                 []DefinedComponent          `json:"components,omitempty" yaml:"components,omitempty"`
+	ImportComponentDefinitions []ImportComponentDefinition `json:"import-component-definitions,omitempty" yaml:"import-component-definitions,omitempty"`
+	Metadata                   Metadata                    `json:"metadata" yaml:"metadata"`
+	UUID                       string                      `json:"uuid" yaml:"uuid"`
+}
+
+type ControlImplementation struct {
+	Description             string                   `json:"description" yaml:"description"`
+	ImplementedRequirements []ImplementedRequirement `json:"implemented-requirements" yaml:"implemented-requirements"`
+	Links                   []Link                   `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                   []Property               `json:"props,omitempty" yaml:"props,omitempty"`
+	SetParameters           []SetParameter           `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Source                  string                   `json:"source" yaml:"source"`
+	UUID                    string                   `json:"uuid" yaml:"uuid"`
+}
+
+type DefinedComponent struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Protocols              []Protocol              `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	Purpose                string                  `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles       []ResponsibleRole       `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Title                  string                  `json:"title" yaml:"title"`
+	Type                   string                  `json:"type" yaml:"type"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ImplementedRequirement struct {
+	ControlId        string            `json:"control-id" yaml:"control-id"`
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	SetParameters    []SetParameter    `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Statements       []Statement       `json:"statements,omitempty" yaml:"statements,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type ImportComponentDefinition struct {
+	Href string `json:"href" yaml:"href"`
+}
+
+type IncorporatesComponent struct {
+	ComponentUuid string `json:"component-uuid" yaml:"component-uuid"`
+	Description   string `json:"description" yaml:"description"`
+}
+
+type Statement struct {
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	StatementId      string            `json:"statement-id" yaml:"statement-id"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type PortRange struct {
+	End       int    `json:"end,omitempty" yaml:"end,omitempty"`
+	Start     int    `json:"start,omitempty" yaml:"start,omitempty"`
+	Transport string `json:"transport,omitempty" yaml:"transport,omitempty"`
+}
+
+type Protocol struct {
+	Name       string      `json:"name" yaml:"name"`
+	PortRanges []PortRange `json:"port-ranges,omitempty" yaml:"port-ranges,omitempty"`
+	Title      string      `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID       string      `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type SetParameter struct {
+	ParamId string   `json:"param-id" yaml:"param-id"`
+	Remarks string   `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Values  []string `json:"values" yaml:"values"`
+}
+
+type Address struct {
+	AddrLines  []string `json:"addr-lines,omitempty" yaml:"addr-lines,omitempty"`
+	City       string   `json:"city,omitempty" yaml:"city,omitempty"`
+	Country    string   `json:"country,omitempty" yaml:"country,omitempty"`
+	PostalCode string   `json:"postal-code,omitempty" yaml:"postal-code,omitempty"`
+	State      string   `json:"state,omitempty" yaml:"state,omitempty"`
+	Type       string   `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type BackMatter struct {
+	Resources []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type Link struct {
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Rel       string `json:"rel,omitempty" yaml:"rel,omitempty"`
+	Text      string `json:"text,omitempty" yaml:"text,omitempty"`
+}
+
+type Location struct {
+	Address          Address           `json:"address" yaml:"address"`
+	EmailAddresses   []string          `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	TelephoneNumbers []TelephoneNumber `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Urls             []string          `json:"urls,omitempty" yaml:"urls,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type Metadata struct {
+	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
+	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
+	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
+	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
+	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
+	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
+	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
+	Roles              []Role             `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Title              string             `json:"title" yaml:"title"`
+	Version            string             `json:"version" yaml:"version"`
+}
+
+type Party struct {
+	Addresses             []Address                 `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	EmailAddresses        []string                  `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	ExternalIds           []PartyExternalIdentifier `json:"external-ids,omitempty" yaml:"external-ids,omitempty"`
+	Links                 []Link                    `json:"links,omitempty" yaml:"links,omitempty"`
+	LocationUuids         []string                  `json:"location-uuids,omitempty" yaml:"location-uuids,omitempty"`
+	MemberOfOrganizations []string                  `json:"member-of-organizations,omitempty" yaml:"member-of-organizations,omitempty"`
+	Name                  string                    `json:"name,omitempty" yaml:"name,omitempty"`
+	Props                 []Property                `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks               string                    `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName             string                    `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	TelephoneNumbers      []TelephoneNumber         `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Type                  string                    `json:"type" yaml:"type"`
+	UUID                  string                    `json:"uuid" yaml:"uuid"`
+}
+
+type Property struct {
+	Class   string `json:"class,omitempty" yaml:"class,omitempty"`
+	Name    string `json:"name" yaml:"name"`
+	Ns      string `json:"ns,omitempty" yaml:"ns,omitempty"`
+	Remarks string `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID    string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Value   string `json:"value" yaml:"value"`
+}
+
+type ResponsibleParty struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids" yaml:"party-uuids"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type ResponsibleRole struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids,omitempty" yaml:"party-uuids,omitempty"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type Revision struct {
+	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
+	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
+	Version      string     `json:"version" yaml:"version"`
+}
+
+type Role struct {
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	ID          string     `json:"id" yaml:"id"`
+	Links       []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props       []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName   string     `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	Title       string     `json:"title" yaml:"title"`
+}
+
+type DocumentId struct {
+	Identifier string `json:"identifier" yaml:"identifier"`
+	Scheme     string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type Hash struct {
+	Algorithm string `json:"algorithm" yaml:"algorithm"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type TelephoneNumber struct {
+	Number string `json:"number" yaml:"number"`
+	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type Base64 struct {
+	Filename  string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type Citation struct {
+	Links []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Text  string     `json:"text" yaml:"text"`
+}
+
+type PartyExternalIdentifier struct {
+	ID     string `json:"id" yaml:"id"`
+	Scheme string `json:"scheme" yaml:"scheme"`
+}
+
+type Resource struct {
+	Base64      Base64         `json:"base64,omitempty" yaml:"base64,omitempty"`
+	Citation    Citation       `json:"citation,omitempty" yaml:"citation,omitempty"`
+	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
+	DocumentIds []DocumentId   `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	Props       []Property     `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string         `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Rlinks      []ResourceLink `json:"rlinks,omitempty" yaml:"rlinks,omitempty"`
+	Title       string         `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID        string         `json:"uuid" yaml:"uuid"`
+}
+
+type ResourceLink struct {
+	Hashes    []Hash `json:"hashes,omitempty" yaml:"hashes,omitempty"`
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+}

--- a/src/types/oscal-1-0-5/component-definition/types.go
+++ b/src/types/oscal-1-0-5/component-definition/types.go
@@ -1,0 +1,276 @@
+/*
+	This file was auto-generated with go-oscal.
+
+	To regenerate:
+
+	go-oscal \
+		--input-file <path_to_oscal_json_schema_file> \
+		--output-file <name_of_go_types_file> // the path to this file must already exist \
+		--tags json,yaml // the tags to add to the Go structs \
+		--pkg <name_of_your_go_package> // defaults to "main"
+
+	For more information on how to use go-oscal: go-oscal --help
+
+	Source: https://github.com/defenseunicorns/go-oscal
+*/
+
+package compdeftypes
+
+type OscalComponentDefinitionModel struct {
+	ComponentDefinition ComponentDefinition `json:"component-definition" yaml:"component-definition"`
+}
+
+type Capability struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	IncorporatesComponents []IncorporatesComponent `json:"incorporates-components,omitempty" yaml:"incorporates-components,omitempty"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Name                   string                  `json:"name" yaml:"name"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ComponentDefinition struct {
+	BackMatter                 BackMatter                  `json:"back-matter,omitempty" yaml:"back-matter,omitempty"`
+	Capabilities               []Capability                `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	Components                 []DefinedComponent          `json:"components,omitempty" yaml:"components,omitempty"`
+	ImportComponentDefinitions []ImportComponentDefinition `json:"import-component-definitions,omitempty" yaml:"import-component-definitions,omitempty"`
+	Metadata                   Metadata                    `json:"metadata" yaml:"metadata"`
+	UUID                       string                      `json:"uuid" yaml:"uuid"`
+}
+
+type ControlImplementation struct {
+	Description             string                   `json:"description" yaml:"description"`
+	ImplementedRequirements []ImplementedRequirement `json:"implemented-requirements" yaml:"implemented-requirements"`
+	Links                   []Link                   `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                   []Property               `json:"props,omitempty" yaml:"props,omitempty"`
+	SetParameters           []SetParameter           `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Source                  string                   `json:"source" yaml:"source"`
+	UUID                    string                   `json:"uuid" yaml:"uuid"`
+}
+
+type DefinedComponent struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Protocols              []Protocol              `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	Purpose                string                  `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles       []ResponsibleRole       `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Title                  string                  `json:"title" yaml:"title"`
+	Type                   string                  `json:"type" yaml:"type"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ImplementedRequirement struct {
+	ControlId        string            `json:"control-id" yaml:"control-id"`
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	SetParameters    []SetParameter    `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Statements       []Statement       `json:"statements,omitempty" yaml:"statements,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type ImportComponentDefinition struct {
+	Href string `json:"href" yaml:"href"`
+}
+
+type IncorporatesComponent struct {
+	ComponentUuid string `json:"component-uuid" yaml:"component-uuid"`
+	Description   string `json:"description" yaml:"description"`
+}
+
+type Statement struct {
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	StatementId      string            `json:"statement-id" yaml:"statement-id"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type PortRange struct {
+	End       int    `json:"end,omitempty" yaml:"end,omitempty"`
+	Start     int    `json:"start,omitempty" yaml:"start,omitempty"`
+	Transport string `json:"transport,omitempty" yaml:"transport,omitempty"`
+}
+
+type Protocol struct {
+	Name       string      `json:"name" yaml:"name"`
+	PortRanges []PortRange `json:"port-ranges,omitempty" yaml:"port-ranges,omitempty"`
+	Title      string      `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID       string      `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type SetParameter struct {
+	ParamId string   `json:"param-id" yaml:"param-id"`
+	Remarks string   `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Values  []string `json:"values" yaml:"values"`
+}
+
+type Address struct {
+	AddrLines  []string `json:"addr-lines,omitempty" yaml:"addr-lines,omitempty"`
+	City       string   `json:"city,omitempty" yaml:"city,omitempty"`
+	Country    string   `json:"country,omitempty" yaml:"country,omitempty"`
+	PostalCode string   `json:"postal-code,omitempty" yaml:"postal-code,omitempty"`
+	State      string   `json:"state,omitempty" yaml:"state,omitempty"`
+	Type       string   `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type BackMatter struct {
+	Resources []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type Link struct {
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Rel       string `json:"rel,omitempty" yaml:"rel,omitempty"`
+	Text      string `json:"text,omitempty" yaml:"text,omitempty"`
+}
+
+type Location struct {
+	Address          Address           `json:"address" yaml:"address"`
+	EmailAddresses   []string          `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	TelephoneNumbers []TelephoneNumber `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Urls             []string          `json:"urls,omitempty" yaml:"urls,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type Metadata struct {
+	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
+	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
+	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
+	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
+	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
+	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
+	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
+	Roles              []Role             `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Title              string             `json:"title" yaml:"title"`
+	Version            string             `json:"version" yaml:"version"`
+}
+
+type Party struct {
+	Addresses             []Address                 `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	EmailAddresses        []string                  `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	ExternalIds           []PartyExternalIdentifier `json:"external-ids,omitempty" yaml:"external-ids,omitempty"`
+	Links                 []Link                    `json:"links,omitempty" yaml:"links,omitempty"`
+	LocationUuids         []string                  `json:"location-uuids,omitempty" yaml:"location-uuids,omitempty"`
+	MemberOfOrganizations []string                  `json:"member-of-organizations,omitempty" yaml:"member-of-organizations,omitempty"`
+	Name                  string                    `json:"name,omitempty" yaml:"name,omitempty"`
+	Props                 []Property                `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks               string                    `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName             string                    `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	TelephoneNumbers      []TelephoneNumber         `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Type                  string                    `json:"type" yaml:"type"`
+	UUID                  string                    `json:"uuid" yaml:"uuid"`
+}
+
+type Property struct {
+	Class   string `json:"class,omitempty" yaml:"class,omitempty"`
+	Name    string `json:"name" yaml:"name"`
+	Ns      string `json:"ns,omitempty" yaml:"ns,omitempty"`
+	Remarks string `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID    string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Value   string `json:"value" yaml:"value"`
+}
+
+type ResponsibleParty struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids" yaml:"party-uuids"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type ResponsibleRole struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids,omitempty" yaml:"party-uuids,omitempty"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type Revision struct {
+	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
+	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
+	Version      string     `json:"version" yaml:"version"`
+}
+
+type Role struct {
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	ID          string     `json:"id" yaml:"id"`
+	Links       []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props       []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName   string     `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	Title       string     `json:"title" yaml:"title"`
+}
+
+type DocumentId struct {
+	Identifier string `json:"identifier" yaml:"identifier"`
+	Scheme     string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type Hash struct {
+	Algorithm string `json:"algorithm" yaml:"algorithm"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type TelephoneNumber struct {
+	Number string `json:"number" yaml:"number"`
+	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type Base64 struct {
+	Filename  string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type Citation struct {
+	Links []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Text  string     `json:"text" yaml:"text"`
+}
+
+type PartyExternalIdentifier struct {
+	ID     string `json:"id" yaml:"id"`
+	Scheme string `json:"scheme" yaml:"scheme"`
+}
+
+type Resource struct {
+	Base64      Base64         `json:"base64,omitempty" yaml:"base64,omitempty"`
+	Citation    Citation       `json:"citation,omitempty" yaml:"citation,omitempty"`
+	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
+	DocumentIds []DocumentId   `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	Props       []Property     `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string         `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Rlinks      []ResourceLink `json:"rlinks,omitempty" yaml:"rlinks,omitempty"`
+	Title       string         `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID        string         `json:"uuid" yaml:"uuid"`
+}
+
+type ResourceLink struct {
+	Hashes    []Hash `json:"hashes,omitempty" yaml:"hashes,omitempty"`
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+}

--- a/src/types/oscal-1-0-6/component-definition/types.go
+++ b/src/types/oscal-1-0-6/component-definition/types.go
@@ -1,0 +1,276 @@
+/*
+	This file was auto-generated with go-oscal.
+
+	To regenerate:
+
+	go-oscal \
+		--input-file <path_to_oscal_json_schema_file> \
+		--output-file <name_of_go_types_file> // the path to this file must already exist \
+		--tags json,yaml // the tags to add to the Go structs \
+		--pkg <name_of_your_go_package> // defaults to "main"
+
+	For more information on how to use go-oscal: go-oscal --help
+
+	Source: https://github.com/defenseunicorns/go-oscal
+*/
+
+package compdeftypes
+
+type OscalComponentDefinitionModel struct {
+	ComponentDefinition ComponentDefinition `json:"component-definition" yaml:"component-definition"`
+}
+
+type Capability struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	IncorporatesComponents []IncorporatesComponent `json:"incorporates-components,omitempty" yaml:"incorporates-components,omitempty"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Name                   string                  `json:"name" yaml:"name"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ComponentDefinition struct {
+	BackMatter                 BackMatter                  `json:"back-matter,omitempty" yaml:"back-matter,omitempty"`
+	Capabilities               []Capability                `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	Components                 []DefinedComponent          `json:"components,omitempty" yaml:"components,omitempty"`
+	ImportComponentDefinitions []ImportComponentDefinition `json:"import-component-definitions,omitempty" yaml:"import-component-definitions,omitempty"`
+	Metadata                   Metadata                    `json:"metadata" yaml:"metadata"`
+	UUID                       string                      `json:"uuid" yaml:"uuid"`
+}
+
+type ControlImplementation struct {
+	Description             string                   `json:"description" yaml:"description"`
+	ImplementedRequirements []ImplementedRequirement `json:"implemented-requirements" yaml:"implemented-requirements"`
+	Links                   []Link                   `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                   []Property               `json:"props,omitempty" yaml:"props,omitempty"`
+	SetParameters           []SetParameter           `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Source                  string                   `json:"source" yaml:"source"`
+	UUID                    string                   `json:"uuid" yaml:"uuid"`
+}
+
+type DefinedComponent struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Protocols              []Protocol              `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	Purpose                string                  `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles       []ResponsibleRole       `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Title                  string                  `json:"title" yaml:"title"`
+	Type                   string                  `json:"type" yaml:"type"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ImplementedRequirement struct {
+	ControlId        string            `json:"control-id" yaml:"control-id"`
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	SetParameters    []SetParameter    `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Statements       []Statement       `json:"statements,omitempty" yaml:"statements,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type ImportComponentDefinition struct {
+	Href string `json:"href" yaml:"href"`
+}
+
+type IncorporatesComponent struct {
+	ComponentUuid string `json:"component-uuid" yaml:"component-uuid"`
+	Description   string `json:"description" yaml:"description"`
+}
+
+type Statement struct {
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	StatementId      string            `json:"statement-id" yaml:"statement-id"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type PortRange struct {
+	End       int    `json:"end,omitempty" yaml:"end,omitempty"`
+	Start     int    `json:"start,omitempty" yaml:"start,omitempty"`
+	Transport string `json:"transport,omitempty" yaml:"transport,omitempty"`
+}
+
+type Protocol struct {
+	Name       string      `json:"name" yaml:"name"`
+	PortRanges []PortRange `json:"port-ranges,omitempty" yaml:"port-ranges,omitempty"`
+	Title      string      `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID       string      `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type SetParameter struct {
+	ParamId string   `json:"param-id" yaml:"param-id"`
+	Remarks string   `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Values  []string `json:"values" yaml:"values"`
+}
+
+type Address struct {
+	AddrLines  []string `json:"addr-lines,omitempty" yaml:"addr-lines,omitempty"`
+	City       string   `json:"city,omitempty" yaml:"city,omitempty"`
+	Country    string   `json:"country,omitempty" yaml:"country,omitempty"`
+	PostalCode string   `json:"postal-code,omitempty" yaml:"postal-code,omitempty"`
+	State      string   `json:"state,omitempty" yaml:"state,omitempty"`
+	Type       string   `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type BackMatter struct {
+	Resources []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type Link struct {
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Rel       string `json:"rel,omitempty" yaml:"rel,omitempty"`
+	Text      string `json:"text,omitempty" yaml:"text,omitempty"`
+}
+
+type Location struct {
+	Address          Address           `json:"address" yaml:"address"`
+	EmailAddresses   []string          `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	TelephoneNumbers []TelephoneNumber `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Urls             []string          `json:"urls,omitempty" yaml:"urls,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type Metadata struct {
+	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
+	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
+	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
+	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
+	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
+	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
+	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
+	Roles              []Role             `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Title              string             `json:"title" yaml:"title"`
+	Version            string             `json:"version" yaml:"version"`
+}
+
+type Party struct {
+	Addresses             []Address                 `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	EmailAddresses        []string                  `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	ExternalIds           []PartyExternalIdentifier `json:"external-ids,omitempty" yaml:"external-ids,omitempty"`
+	Links                 []Link                    `json:"links,omitempty" yaml:"links,omitempty"`
+	LocationUuids         []string                  `json:"location-uuids,omitempty" yaml:"location-uuids,omitempty"`
+	MemberOfOrganizations []string                  `json:"member-of-organizations,omitempty" yaml:"member-of-organizations,omitempty"`
+	Name                  string                    `json:"name,omitempty" yaml:"name,omitempty"`
+	Props                 []Property                `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks               string                    `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName             string                    `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	TelephoneNumbers      []TelephoneNumber         `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Type                  string                    `json:"type" yaml:"type"`
+	UUID                  string                    `json:"uuid" yaml:"uuid"`
+}
+
+type Property struct {
+	Class   string `json:"class,omitempty" yaml:"class,omitempty"`
+	Name    string `json:"name" yaml:"name"`
+	Ns      string `json:"ns,omitempty" yaml:"ns,omitempty"`
+	Remarks string `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID    string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Value   string `json:"value" yaml:"value"`
+}
+
+type ResponsibleParty struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids" yaml:"party-uuids"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type ResponsibleRole struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids,omitempty" yaml:"party-uuids,omitempty"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type Revision struct {
+	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
+	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
+	Version      string     `json:"version" yaml:"version"`
+}
+
+type Role struct {
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	ID          string     `json:"id" yaml:"id"`
+	Links       []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props       []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName   string     `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	Title       string     `json:"title" yaml:"title"`
+}
+
+type DocumentId struct {
+	Identifier string `json:"identifier" yaml:"identifier"`
+	Scheme     string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type Hash struct {
+	Algorithm string `json:"algorithm" yaml:"algorithm"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type TelephoneNumber struct {
+	Number string `json:"number" yaml:"number"`
+	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type Base64 struct {
+	Filename  string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type Citation struct {
+	Links []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Text  string     `json:"text" yaml:"text"`
+}
+
+type PartyExternalIdentifier struct {
+	ID     string `json:"id" yaml:"id"`
+	Scheme string `json:"scheme" yaml:"scheme"`
+}
+
+type Resource struct {
+	Base64      Base64         `json:"base64,omitempty" yaml:"base64,omitempty"`
+	Citation    Citation       `json:"citation,omitempty" yaml:"citation,omitempty"`
+	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
+	DocumentIds []DocumentId   `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	Props       []Property     `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string         `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Rlinks      []ResourceLink `json:"rlinks,omitempty" yaml:"rlinks,omitempty"`
+	Title       string         `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID        string         `json:"uuid" yaml:"uuid"`
+}
+
+type ResourceLink struct {
+	Hashes    []Hash `json:"hashes,omitempty" yaml:"hashes,omitempty"`
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+}

--- a/src/types/oscal-1-1-0/component-definition/types.go
+++ b/src/types/oscal-1-1-0/component-definition/types.go
@@ -1,0 +1,290 @@
+/*
+	This file was auto-generated with go-oscal.
+
+	To regenerate:
+
+	go-oscal \
+		--input-file <path_to_oscal_json_schema_file> \
+		--output-file <name_of_go_types_file> // the path to this file must already exist \
+		--tags json,yaml // the tags to add to the Go structs \
+		--pkg <name_of_your_go_package> // defaults to "main"
+
+	For more information on how to use go-oscal: go-oscal --help
+
+	Source: https://github.com/defenseunicorns/go-oscal
+*/
+
+package compdeftypes
+
+type OscalComponentDefinitionModel struct {
+	ComponentDefinition ComponentDefinition `json:"component-definition" yaml:"component-definition"`
+}
+
+type Capability struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	IncorporatesComponents []IncorporatesComponent `json:"incorporates-components,omitempty" yaml:"incorporates-components,omitempty"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Name                   string                  `json:"name" yaml:"name"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ComponentDefinition struct {
+	BackMatter                 BackMatter                  `json:"back-matter,omitempty" yaml:"back-matter,omitempty"`
+	Capabilities               []Capability                `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	Components                 []DefinedComponent          `json:"components,omitempty" yaml:"components,omitempty"`
+	ImportComponentDefinitions []ImportComponentDefinition `json:"import-component-definitions,omitempty" yaml:"import-component-definitions,omitempty"`
+	Metadata                   Metadata                    `json:"metadata" yaml:"metadata"`
+	UUID                       string                      `json:"uuid" yaml:"uuid"`
+}
+
+type ControlImplementation struct {
+	Description             string                   `json:"description" yaml:"description"`
+	ImplementedRequirements []ImplementedRequirement `json:"implemented-requirements" yaml:"implemented-requirements"`
+	Links                   []Link                   `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                   []Property               `json:"props,omitempty" yaml:"props,omitempty"`
+	SetParameters           []SetParameter           `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Source                  string                   `json:"source" yaml:"source"`
+	UUID                    string                   `json:"uuid" yaml:"uuid"`
+}
+
+type DefinedComponent struct {
+	ControlImplementations []ControlImplementation `json:"control-implementations,omitempty" yaml:"control-implementations,omitempty"`
+	Description            string                  `json:"description" yaml:"description"`
+	Links                  []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
+	Props                  []Property              `json:"props,omitempty" yaml:"props,omitempty"`
+	Protocols              []Protocol              `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	Purpose                string                  `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+	Remarks                string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles       []ResponsibleRole       `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	Title                  string                  `json:"title" yaml:"title"`
+	Type                   string                  `json:"type" yaml:"type"`
+	UUID                   string                  `json:"uuid" yaml:"uuid"`
+}
+
+type ImplementedRequirement struct {
+	ControlId        string            `json:"control-id" yaml:"control-id"`
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	SetParameters    []SetParameter    `json:"set-parameters,omitempty" yaml:"set-parameters,omitempty"`
+	Statements       []Statement       `json:"statements,omitempty" yaml:"statements,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type ImportComponentDefinition struct {
+	Href string `json:"href" yaml:"href"`
+}
+
+type IncorporatesComponent struct {
+	ComponentUuid string `json:"component-uuid" yaml:"component-uuid"`
+	Description   string `json:"description" yaml:"description"`
+}
+
+type Statement struct {
+	Description      string            `json:"description" yaml:"description"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleRoles []ResponsibleRole `json:"responsible-roles,omitempty" yaml:"responsible-roles,omitempty"`
+	StatementId      string            `json:"statement-id" yaml:"statement-id"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type PortRange struct {
+	End       int    `json:"end,omitempty" yaml:"end,omitempty"`
+	Start     int    `json:"start,omitempty" yaml:"start,omitempty"`
+	Transport string `json:"transport,omitempty" yaml:"transport,omitempty"`
+}
+
+type Protocol struct {
+	Name       string      `json:"name" yaml:"name"`
+	PortRanges []PortRange `json:"port-ranges,omitempty" yaml:"port-ranges,omitempty"`
+	Title      string      `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID       string      `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type SetParameter struct {
+	ParamId string   `json:"param-id" yaml:"param-id"`
+	Remarks string   `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Values  []string `json:"values" yaml:"values"`
+}
+
+type Action struct {
+	Date               string             `json:"date,omitempty" yaml:"date,omitempty"`
+	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
+	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
+	System             string             `json:"system" yaml:"system"`
+	Type               string             `json:"type" yaml:"type"`
+	UUID               string             `json:"uuid" yaml:"uuid"`
+}
+
+type Address struct {
+	AddrLines  []string `json:"addr-lines,omitempty" yaml:"addr-lines,omitempty"`
+	City       string   `json:"city,omitempty" yaml:"city,omitempty"`
+	Country    string   `json:"country,omitempty" yaml:"country,omitempty"`
+	PostalCode string   `json:"postal-code,omitempty" yaml:"postal-code,omitempty"`
+	State      string   `json:"state,omitempty" yaml:"state,omitempty"`
+	Type       string   `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type BackMatter struct {
+	Resources []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type Link struct {
+	Href             string `json:"href" yaml:"href"`
+	MediaType        string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Rel              string `json:"rel,omitempty" yaml:"rel,omitempty"`
+	ResourceFragment string `json:"resource-fragment,omitempty" yaml:"resource-fragment,omitempty"`
+	Text             string `json:"text,omitempty" yaml:"text,omitempty"`
+}
+
+type Metadata struct {
+	Actions            []Action               `json:"actions,omitempty" yaml:"actions,omitempty"`
+	DocumentIds        []DocumentId           `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	LastModified       string                 `json:"last-modified" yaml:"last-modified"`
+	Links              []Link                 `json:"links,omitempty" yaml:"links,omitempty"`
+	Locations          []Location             `json:"locations,omitempty" yaml:"locations,omitempty"`
+	OscalVersion       string                 `json:"oscal-version" yaml:"oscal-version"`
+	Parties            []Party                `json:"parties,omitempty" yaml:"parties,omitempty"`
+	Props              []Property             `json:"props,omitempty" yaml:"props,omitempty"`
+	Published          string                 `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks            string                 `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ResponsibleParties []ResponsibleParty     `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
+	Revisions          []RevisionHistoryEntry `json:"revisions,omitempty" yaml:"revisions,omitempty"`
+	Roles              []Role                 `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Title              string                 `json:"title" yaml:"title"`
+	Version            string                 `json:"version" yaml:"version"`
+}
+
+type Property struct {
+	Class   string `json:"class,omitempty" yaml:"class,omitempty"`
+	Group   string `json:"group,omitempty" yaml:"group,omitempty"`
+	Name    string `json:"name" yaml:"name"`
+	Ns      string `json:"ns,omitempty" yaml:"ns,omitempty"`
+	Remarks string `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	UUID    string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+	Value   string `json:"value" yaml:"value"`
+}
+
+type ResponsibleParty struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids" yaml:"party-uuids"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type ResponsibleRole struct {
+	Links      []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	PartyUuids []string   `json:"party-uuids,omitempty" yaml:"party-uuids,omitempty"`
+	Props      []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks    string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	RoleId     string     `json:"role-id" yaml:"role-id"`
+}
+
+type DocumentId struct {
+	Identifier string `json:"identifier" yaml:"identifier"`
+	Scheme     string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+}
+
+type Hash struct {
+	Algorithm string `json:"algorithm" yaml:"algorithm"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type TelephoneNumber struct {
+	Number string `json:"number" yaml:"number"`
+	Type   string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type Base64 struct {
+	Filename  string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+	Value     string `json:"value" yaml:"value"`
+}
+
+type Citation struct {
+	Links []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Text  string     `json:"text" yaml:"text"`
+}
+
+type PartyExternalIdentifier struct {
+	ID     string `json:"id" yaml:"id"`
+	Scheme string `json:"scheme" yaml:"scheme"`
+}
+
+type Location struct {
+	Address          Address           `json:"address,omitempty" yaml:"address,omitempty"`
+	EmailAddresses   []string          `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	Links            []Link            `json:"links,omitempty" yaml:"links,omitempty"`
+	Props            []Property        `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks          string            `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	TelephoneNumbers []TelephoneNumber `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Urls             []string          `json:"urls,omitempty" yaml:"urls,omitempty"`
+	UUID             string            `json:"uuid" yaml:"uuid"`
+}
+
+type Party struct {
+	Addresses             []Address                 `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+	EmailAddresses        []string                  `json:"email-addresses,omitempty" yaml:"email-addresses,omitempty"`
+	ExternalIds           []PartyExternalIdentifier `json:"external-ids,omitempty" yaml:"external-ids,omitempty"`
+	Links                 []Link                    `json:"links,omitempty" yaml:"links,omitempty"`
+	LocationUuids         []string                  `json:"location-uuids,omitempty" yaml:"location-uuids,omitempty"`
+	MemberOfOrganizations []string                  `json:"member-of-organizations,omitempty" yaml:"member-of-organizations,omitempty"`
+	Name                  string                    `json:"name,omitempty" yaml:"name,omitempty"`
+	Props                 []Property                `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks               string                    `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName             string                    `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	TelephoneNumbers      []TelephoneNumber         `json:"telephone-numbers,omitempty" yaml:"telephone-numbers,omitempty"`
+	Type                  string                    `json:"type" yaml:"type"`
+	UUID                  string                    `json:"uuid" yaml:"uuid"`
+}
+
+type Resource struct {
+	Base64      Base64         `json:"base64,omitempty" yaml:"base64,omitempty"`
+	Citation    Citation       `json:"citation,omitempty" yaml:"citation,omitempty"`
+	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
+	DocumentIds []DocumentId   `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
+	Props       []Property     `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string         `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Rlinks      []ResourceLink `json:"rlinks,omitempty" yaml:"rlinks,omitempty"`
+	Title       string         `json:"title,omitempty" yaml:"title,omitempty"`
+	UUID        string         `json:"uuid" yaml:"uuid"`
+}
+
+type RevisionHistoryEntry struct {
+	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
+	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
+	Version      string     `json:"version" yaml:"version"`
+}
+
+type ResourceLink struct {
+	Hashes    []Hash `json:"hashes,omitempty" yaml:"hashes,omitempty"`
+	Href      string `json:"href" yaml:"href"`
+	MediaType string `json:"media-type,omitempty" yaml:"media-type,omitempty"`
+}
+
+type Role struct {
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	ID          string     `json:"id" yaml:"id"`
+	Links       []Link     `json:"links,omitempty" yaml:"links,omitempty"`
+	Props       []Property `json:"props,omitempty" yaml:"props,omitempty"`
+	Remarks     string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
+	ShortName   string     `json:"short-name,omitempty" yaml:"short-name,omitempty"`
+	Title       string     `json:"title" yaml:"title"`
+}


### PR DESCRIPTION
Precursor to implementing logic for #33 

Migrate generation logic to a `generate` subcommand and create a placeholder `convert` for converting oscal files from and older version to a newer (at least this opinionation to start). 