### PR TITLE
Fix: add omitempty for marshall process

### DIFF
--- a/schema/component/expected-oscal-model-struct.txt
+++ b/schema/component/expected-oscal-model-struct.txt
@@ -1,3 +1,3 @@
 type OscalModels struct {
-	ComponentDefinition ComponentDefinition `json:"component-definition" yaml:"component-definition"`
+	ComponentDefinition ComponentDefinition `json:"component-definition,omitempty" yaml:"component-definition,omitempty"`
 }

--- a/schema/ssp/expected-oscal-model-struct.txt
+++ b/schema/ssp/expected-oscal-model-struct.txt
@@ -1,3 +1,3 @@
 type OscalModels struct {
-	SystemSecurityPlan SystemSecurityPlan `json:"system-security-plan" yaml:"system-security-plan"`
+	SystemSecurityPlan SystemSecurityPlan `json:"system-security-plan,omitempty" yaml:"system-security-plan,omitempty"`
 }

--- a/src/internal/oscal/generate.go
+++ b/src/internal/oscal/generate.go
@@ -24,7 +24,7 @@ const headerComment string = `/*
 
 	To regenerate:
 	
-	go-oscal \
+	go-oscal generate \
 		--input-file <path_to_oscal_json_schema_file> \
 		--output-file <name_of_go_types_file> // the path to this file must already exist \
 		--tags json,yaml // the tags to add to the Go structs \
@@ -544,7 +544,7 @@ func generateOscalModelStruct(oscalModels []string, pkgName string, tags []strin
 		// Format struct tags.
 		tagList := []string{}
 		for _, tag := range tags {
-			tagList = append(tagList, fmt.Sprintf("%s:\"%s\"", tag, oscalModel))
+			tagList = append(tagList, fmt.Sprintf("%s:\"%s,omitempty\"", tag, oscalModel))
 		}
 
 		structString += fmt.Sprintf("\t%s %s `%s`\n", formattedOscalModelName, formattedOscalModelName, strings.Join(tagList, " "))

--- a/src/types/oscal-1-0-4/types.go
+++ b/src/types/oscal-1-0-4/types.go
@@ -17,13 +17,13 @@
 package oscalTypes
 
 type OscalModels struct {
-	Catalog                   Catalog                   `json:"catalog" yaml:"catalog"`
-	Profile                   Profile                   `json:"profile" yaml:"profile"`
-	ComponentDefinition       ComponentDefinition       `json:"component-definition" yaml:"component-definition"`
-	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan" yaml:"system-security-plan"`
-	AssessmentPlan            AssessmentPlan            `json:"assessment-plan" yaml:"assessment-plan"`
-	AssessmentResults         AssessmentResults         `json:"assessment-results" yaml:"assessment-results"`
-	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones" yaml:"plan-of-action-and-milestones"`
+	Catalog                   Catalog                   `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+	Profile                   Profile                   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	ComponentDefinition       ComponentDefinition       `json:"component-definition,omitempty" yaml:"component-definition,omitempty"`
+	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan,omitempty" yaml:"system-security-plan,omitempty"`
+	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
+	AssessmentResults         AssessmentResults         `json:"assessment-results,omitempty" yaml:"assessment-results,omitempty"`
+	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones,omitempty" yaml:"plan-of-action-and-milestones,omitempty"`
 }
 
 type AssessmentPlan struct {

--- a/src/types/oscal-1-0-5/types.go
+++ b/src/types/oscal-1-0-5/types.go
@@ -17,13 +17,13 @@
 package oscalTypes
 
 type OscalModels struct {
-	Catalog                   Catalog                   `json:"catalog" yaml:"catalog"`
-	Profile                   Profile                   `json:"profile" yaml:"profile"`
-	ComponentDefinition       ComponentDefinition       `json:"component-definition" yaml:"component-definition"`
-	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan" yaml:"system-security-plan"`
-	AssessmentPlan            AssessmentPlan            `json:"assessment-plan" yaml:"assessment-plan"`
-	AssessmentResults         AssessmentResults         `json:"assessment-results" yaml:"assessment-results"`
-	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones" yaml:"plan-of-action-and-milestones"`
+	Catalog                   Catalog                   `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+	Profile                   Profile                   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	ComponentDefinition       ComponentDefinition       `json:"component-definition,omitempty" yaml:"component-definition,omitempty"`
+	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan,omitempty" yaml:"system-security-plan,omitempty"`
+	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
+	AssessmentResults         AssessmentResults         `json:"assessment-results,omitempty" yaml:"assessment-results,omitempty"`
+	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones,omitempty" yaml:"plan-of-action-and-milestones,omitempty"`
 }
 
 type AssessmentPlan struct {

--- a/src/types/oscal-1-0-6/types.go
+++ b/src/types/oscal-1-0-6/types.go
@@ -17,13 +17,13 @@
 package oscalTypes
 
 type OscalModels struct {
-	Catalog                   Catalog                   `json:"catalog" yaml:"catalog"`
-	Profile                   Profile                   `json:"profile" yaml:"profile"`
-	ComponentDefinition       ComponentDefinition       `json:"component-definition" yaml:"component-definition"`
-	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan" yaml:"system-security-plan"`
-	AssessmentPlan            AssessmentPlan            `json:"assessment-plan" yaml:"assessment-plan"`
-	AssessmentResults         AssessmentResults         `json:"assessment-results" yaml:"assessment-results"`
-	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones" yaml:"plan-of-action-and-milestones"`
+	Catalog                   Catalog                   `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+	Profile                   Profile                   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	ComponentDefinition       ComponentDefinition       `json:"component-definition,omitempty" yaml:"component-definition,omitempty"`
+	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan,omitempty" yaml:"system-security-plan,omitempty"`
+	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
+	AssessmentResults         AssessmentResults         `json:"assessment-results,omitempty" yaml:"assessment-results,omitempty"`
+	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones,omitempty" yaml:"plan-of-action-and-milestones,omitempty"`
 }
 
 type AssessmentPlan struct {

--- a/src/types/oscal-1-1-0/types.go
+++ b/src/types/oscal-1-1-0/types.go
@@ -17,13 +17,13 @@
 package oscalTypes
 
 type OscalModels struct {
-	Catalog                   Catalog                   `json:"catalog" yaml:"catalog"`
-	Profile                   Profile                   `json:"profile" yaml:"profile"`
-	ComponentDefinition       ComponentDefinition       `json:"component-definition" yaml:"component-definition"`
-	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan" yaml:"system-security-plan"`
-	AssessmentPlan            AssessmentPlan            `json:"assessment-plan" yaml:"assessment-plan"`
-	AssessmentResults         AssessmentResults         `json:"assessment-results" yaml:"assessment-results"`
-	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones" yaml:"plan-of-action-and-milestones"`
+	Catalog                   Catalog                   `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+	Profile                   Profile                   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	ComponentDefinition       ComponentDefinition       `json:"component-definition,omitempty" yaml:"component-definition,omitempty"`
+	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan,omitempty" yaml:"system-security-plan,omitempty"`
+	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
+	AssessmentResults         AssessmentResults         `json:"assessment-results,omitempty" yaml:"assessment-results,omitempty"`
+	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones,omitempty" yaml:"plan-of-action-and-milestones,omitempty"`
 }
 
 type AssessmentPlan struct {

--- a/src/types/oscal-1-1-1/types.go
+++ b/src/types/oscal-1-1-1/types.go
@@ -17,13 +17,13 @@
 package oscalTypes
 
 type OscalModels struct {
-	Catalog                   Catalog                   `json:"catalog" yaml:"catalog"`
-	Profile                   Profile                   `json:"profile" yaml:"profile"`
-	ComponentDefinition       ComponentDefinition       `json:"component-definition" yaml:"component-definition"`
-	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan" yaml:"system-security-plan"`
-	AssessmentPlan            AssessmentPlan            `json:"assessment-plan" yaml:"assessment-plan"`
-	AssessmentResults         AssessmentResults         `json:"assessment-results" yaml:"assessment-results"`
-	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones" yaml:"plan-of-action-and-milestones"`
+	Catalog                   Catalog                   `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+	Profile                   Profile                   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	ComponentDefinition       ComponentDefinition       `json:"component-definition,omitempty" yaml:"component-definition,omitempty"`
+	SystemSecurityPlan        SystemSecurityPlan        `json:"system-security-plan,omitempty" yaml:"system-security-plan,omitempty"`
+	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
+	AssessmentResults         AssessmentResults         `json:"assessment-results,omitempty" yaml:"assessment-results,omitempty"`
+	PlanOfActionAndMilestones PlanOfActionAndMilestones `json:"plan-of-action-and-milestones,omitempty" yaml:"plan-of-action-and-milestones,omitempty"`
 }
 
 type AssessmentPlan struct {


### PR DESCRIPTION
Now that we are exposing the types for import elsewhere - we need to `omitempty` the top level struct to allow individual models to marshall while writing to file. 