### PR TITLE
feat: initial release process

### DIFF
--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -1,0 +1,15 @@
+name: save-logs
+description: "Save debug logs"
+
+runs:
+  using: composite
+  steps:
+    - name: Fix log permissions
+      run: |
+        sudo chown $USER /tmp/go-oscal-*.log || echo ""
+      shell: bash
+
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      with:
+        name: debug-log
+        path: /tmp/go-oscal-*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Publish Go-OSCAL Packages on Tag
+
+permissions:
+  contents: read
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Checkout the repo and setup the tooling for this job
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup golang
+        uses: ./.github/actions/golang
+
+      - name: Build CLI
+        run: |
+          make build
+
+      # Upload the contents of the build directory for later stages to use
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: build-artifacts
+          path: bin/
+          retention-days: 1
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Checkout the repo and setup the tooling for this job
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: build-artifacts
+          path: bin/
+
+      - name: Setup golang
+        uses: ./.github/actions/golang
+
+      - name: Make go-oscal executable
+        run: |
+          chmod +x bin/go-oscal
+      
+      # Build the example packages and run the tests
+      - name: Run e2e tests
+        run: |
+          make test
+
+      - name: Save logs
+        if: always()
+        uses: ./.github/actions/save-logs
+
+  push:
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: write
+    steps:
+      # Checkout the repo and setup the tooling for this job
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup golang
+        uses: ./.github/actions/golang
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: build-artifacts
+          path: bin/
+
+      # Create the GitHub release notes
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+before:
+  hooks:
+    - go mod tidy
+
+# Build a universal macOS binary
+universal_binaries:
+  - replace: false
+
+# Build the different combination of goos/arch binaries
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+# Save the built artifacts as binaries (instead of wrapping them in a tarball)
+archives:
+  - format: binary
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{- title .Os }}_{{ .Arch }}"
+
+# generate a sha256 checksum of all release artifacts
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+# generate sboms for each binary artifact
+sboms:
+  - artifacts: binary
+    documents:
+      - "sbom_{{ .ProjectName }}_{{ .Tag }}_{{- title .Os }}_{{ .Arch }}.sbom"
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-snapshot"
+
+# Use the auto-generated changelog github provides
+changelog:
+  use: github-native
+
+# Generate a GitHub release and publish the release for the tag
+release:
+  github:
+    owner: defenseunicorns
+    name: go-oscal
+  prerelease: auto
+  mode: append
+  draft: false

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,53 @@
+# Go-OSCAL Release
+
+This document provides guidance on how to create Go-OSCAL releases, address release issues, and other helpful tips.
+
+## Creating releases
+
+This project uses [goreleaser](https://github.com/goreleaser/goreleaser-action) for releasing binaries.
+
+### How should I write my commits?
+
+We use conventional commit messages [Conventional Commit messages](https://www.conventionalcommits.org/).
+
+The most important prefixes you should have in mind are:
+
+- `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/)
+  patch.
+- `feat:` which represents a new feature, and correlates to a SemVer minor.
+- `feat!:`,  or `fix!:`, `refactor!:`, etc., which represent a breaking change
+  (indicated by the `!`) and will result in a SemVer major.
+
+### How can I influence the version number for a release?
+
+To trigger the goreleaser action you push a signed tag using your GPG key.
+
+```console
+git tag -s vX.X.X -m "Release Commit Message"
+git push origin vX.X.X
+```
+
+### How do I fix a release issue?
+
+There are some different ways that something could go wrong with a release, below are some example scenarios and how to fix them.
+
+#### A release is "broken" and should not be used
+
+Rather than removing a release that is deemed to be broken in some fashion, it should be noted as a broken release in the release notes as soon as possible, and a new release created that fixes the issue(s).
+
+The CHANGELOG is not required to be updated, only the release notes must be updated either manually or with CI automation.
+
+- Manual approach: Find the impacted release, edit the release notes, and put this warning at the top:
+
+```md
+>[!WARNING]
+>PLEASE USE A NEWER VERSION (there are known issues with this release)
+```
+
+#### Other issues and helpful tips
+
+- Confirm that the goreleaser configuration is valid by using the [goreleaser cli](https://goreleaser.com/cmd/goreleaser_check/?h=valid)
+
+```sh
+goreleaser check .goreleaser.yaml [flags]
+```


### PR DESCRIPTION
# Created Initial Release Process
This pr adds the following functionality to setup and aid the release process.
- Creates and saves logs action
- Goreleaser action to creating binary releases
- Goreleaser config for configuring goreleaser action
-  Release process documentation

The config file helps setup goreleaser. It will determine the build binaries and the changelog messages. Currently set to append so it will add each piece to the same changelog for a release. (Similar to Zarf and others)

To do a release you need to have [permissions ](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules#about-tag-protection-rules) to push tags which will trigger the GitHub goreleaser action.

```console
git tag -s vX.X.X -m "Release Commit Message"
git push origin vX.X.X
```

Closes Issue https://github.com/defenseunicorns/go-oscal/issues/46