### PR TITLE
#93. Fix test_output.go beind dumped into the cmd/generate directory …

### DIFF
--- a/src/cmd/generate/generate_test.go
+++ b/src/cmd/generate/generate_test.go
@@ -13,6 +13,7 @@ func TestGenerateCmd(t *testing.T) {
 	testInput := "../../../schema/complete/oscal_complete_schema-1-0-4.json"
 	packageName := "oscalTypes"
 	tags := "json,yaml"
+	tempDir := t.TempDir()
 	GenerateCmd.SetOut(new(bytes.Buffer))
 
 	logOutput := gooscaltest.RedirectLog(t)
@@ -62,7 +63,7 @@ func TestGenerateCmd(t *testing.T) {
 
 	t.Run("output-file", func(t *testing.T) {
 		t.Run("outputs to a file if the -o flag is provided", func(t *testing.T) {
-			outputFile := "test_output.go"
+			outputFile := tempDir + "/test_output.go"
 			GenerateCmd.SetArgs([]string{"-f", testInput, "-o", outputFile})
 			err := GenerateCmd.Execute()
 			if err != nil {


### PR DESCRIPTION
 Fix test_output.go beind dumped into the cmd/generate directory by creating a tempdir and prefixing the output path with the test tempdir.