### PR TITLE
122 generate more refined type generation from schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `doctor` command to prep new oscal_complete_schema.json from [OSCAL Releases](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.2) for use in the `validate` and `revise` commands. Behavior ported from [oscal-json-doctor](https://github.com/defenseunicorns/oscal-json-doctor) in order to keep all needed functionality within the go-oscal repo. 
 - documentation for `generate` and `doctor` commands
 - documentation for upgrading to a new version of OSCAL (docs/upgrading-oscal-version.md)
+- Added support for custom types. 
 
 ### Changed
 - [breaking] Types now belong to unique packages in the format `oscalTypes_X_X_X` (ie: `oscalTypes_1_0_4`)
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Types Changes
 #### oscal types versions: 1.0.4, 1.0.5, 1.0.6, 1.1.0, 1.1.1
+- update fields that are of format `date-time` in schema are now represented as `time.Time` in Types.
 
 - update `AssessmentPlan.TermsAndConditions` is now of type `AssessmentPlanTermsAndConditions` per the schema `title`
   - Renamed from `TermsAndConditions`

--- a/src/internal/generate/generate.go
+++ b/src/internal/generate/generate.go
@@ -59,8 +59,16 @@ func Generate(oscalSchema []byte, pkgName string, tags []string) (typeBytes []by
 
 	// Add header comment
 	typeString := fmt.Sprintf("%s\n", headerComment)
+
 	// Add the package name
 	typeString += fmt.Sprintf("package %s\n\n", pkgName)
+
+	// Add additional imports
+	typeString += "import (\n"
+	for _, imp := range AdditionalImports {
+		typeString += fmt.Sprintf("\t\"%s\"\n", imp)
+	}
+	typeString += ")\n\n"
 
 	// Add the struct definitions in order of creation.
 	for _, ref := range config.refQueue.History() {
@@ -211,7 +219,7 @@ func (c *GeneratorConfig) buildTypeString(property jsonschema.Schema) (propType 
 	var possibleRefs []string
 
 	if property.Type != nil && property.Type.SimpleTypes != nil {
-		jsonType := string(*property.Type.SimpleTypes)
+		jsonType := getJsonType(property)
 		// convert json type to go type
 		propType = getGoType(jsonType)
 		// if the type is not primitive, we need to add the name of the type
@@ -311,7 +319,7 @@ func (c *GeneratorConfig) findSubType(schema jsonschema.Schema) (name string, er
 			err = fmt.Errorf("could not determine name for %v", schema)
 		}
 	default:
-		name = getJsonType(schema)
+		name = simpleType
 	}
 
 	return name, err

--- a/src/internal/generate/generate.go
+++ b/src/internal/generate/generate.go
@@ -215,11 +215,11 @@ func (c *GeneratorConfig) buildTypeString(property jsonschema.Schema) (propType 
 	var possibleRefs []string
 
 	if property.Type != nil && property.Type.SimpleTypes != nil {
-		jsonType := getJsonType(property)
+		jsonType := getJsonOrCustomType(property)
 		// convert json type to go type
 		propType = getGoType(jsonType)
 		// if the type is not primitive, we need to add the name of the type
-		if !isPrimitiveJsonType(jsonType) {
+		if !isPrimitiveOrCustomJsonType(jsonType) {
 			name, err := c.findSubType(property)
 			if err != nil {
 				return "", err
@@ -270,7 +270,7 @@ func (c *GeneratorConfig) buildTypeString(property jsonschema.Schema) (propType 
 
 // findSubType finds the name of the type for the given schema.
 func (c *GeneratorConfig) findSubType(schema jsonschema.Schema) (name string, err error) {
-	simpleType := getJsonType(schema)
+	simpleType := getJsonOrCustomType(schema)
 	switch simpleType {
 	case "object":
 		// If the schema has a ref, we need to find the name of the ref.

--- a/src/internal/generate/generate.go
+++ b/src/internal/generate/generate.go
@@ -64,11 +64,7 @@ func Generate(oscalSchema []byte, pkgName string, tags []string) (typeBytes []by
 	typeString += fmt.Sprintf("package %s\n\n", pkgName)
 
 	// Add additional imports
-	typeString += "import (\n"
-	for _, imp := range AdditionalImports {
-		typeString += fmt.Sprintf("\t\"%s\"\n", imp)
-	}
-	typeString += ")\n\n"
+	typeString += buildImportString()
 
 	// Add the struct definitions in order of creation.
 	for _, ref := range config.refQueue.History() {

--- a/src/internal/generate/generate_utils.go
+++ b/src/internal/generate/generate_utils.go
@@ -10,6 +10,12 @@ import (
 	"github.com/swaggest/jsonschema-go"
 )
 
+var AdditionalImports []string = []string{"time"}
+
+var CustomTypes map[string]string = map[string]string{
+	"date-time": "time.Time",
+}
+
 var RefsToIgnore map[string]bool = map[string]bool{
 	"#json-schema-directive": true,
 }
@@ -137,8 +143,37 @@ func getRefWithName(name string) string {
 	return "#/definitions/" + name
 }
 
+// hasCustomType returns true if the key is associated with a custom type
+func hasCustomType(t string) bool {
+	_, ok := CustomTypes[t]
+	return ok
+}
+
+// getCustomTypeKey returns the custom type key if the schema has a custom type
+func getCustomTypeKey(schema jsonschema.Schema) string {
+	// If the schema has a format, check if it's a custom type
+	if schema.Format != nil {
+		if _, ok := CustomTypes[*schema.Format]; ok {
+			return *schema.Format
+		}
+	}
+	return ""
+}
+
+// getCustomType returns the custom type given a custom type key
+func getCustomType(t string) string {
+	if importType, ok := CustomTypes[t]; ok {
+		return importType
+	}
+	return ""
+}
+
 // returns the json type of the schema
 func getJsonType(schema jsonschema.Schema) string {
+	// if the schema has a custom type, return the custom type
+	if importType := getCustomTypeKey(schema); importType != "" {
+		return importType
+	}
 	if schema.Type != nil {
 		return string(*schema.Type.SimpleTypes)
 	}
@@ -148,6 +183,10 @@ func getJsonType(schema jsonschema.Schema) string {
 // isPrimitiveJsonType returns true if the type is a primitive type
 func isPrimitiveJsonType(t string) bool {
 	lower := strings.ToLower(t)
+	// Handle custom types as primitive types
+	if hasCustomType(lower) {
+		return true
+	}
 	switch lower {
 	case "string":
 		return true
@@ -164,6 +203,12 @@ func isPrimitiveJsonType(t string) bool {
 // getGoType returns the Go type for a given JSON type
 func getGoType(t string) string {
 	lower := strings.ToLower(t)
+
+	// Return custom type if it exists
+	if hasCustomType(lower) {
+		return getCustomType(lower)
+
+	}
 	switch lower {
 	case "string":
 		return "string"

--- a/src/internal/generate/generate_utils.go
+++ b/src/internal/generate/generate_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/swaggest/jsonschema-go"
 )
 
-var AdditionalImports []string = []string{"time"}
+var Imports []string = []string{"time"}
 
 var CustomTypes map[string]string = map[string]string{
 	"date-time": "time.Time",
@@ -402,4 +402,14 @@ func stringifyFirstChar(str string) string {
 	}
 
 	return intToWordMap[i] + "_" + str[1:]
+}
+
+// buildImportString returns a string of imports for the Go file
+func buildImportString() string {
+	imports := "import (\n"
+	for _, imp := range Imports {
+		imports += fmt.Sprintf("\t\"%s\"\n", imp)
+	}
+	imports += ")\n"
+	return imports
 }

--- a/src/internal/generate/generate_utils_test.go
+++ b/src/internal/generate/generate_utils_test.go
@@ -2,6 +2,8 @@ package generate
 
 import (
 	"testing"
+
+	"github.com/swaggest/jsonschema-go"
 )
 
 func TestBuildTagString(t *testing.T) {
@@ -155,6 +157,8 @@ func TestIsPrimitiveJsonType(t *testing.T) {
 		{in: "number", out: true},
 		{in: "integer", out: true},
 		{in: "object", out: false},
+		{in: "array", out: false},
+		{in: "date-time", out: true},
 	}
 
 	for _, testCase := range testCases {
@@ -181,6 +185,7 @@ func TestGetGoType(t *testing.T) {
 		{in: "integer", out: "int"},
 		{in: "array", out: "[]"},
 		{in: "object", out: ""},
+		{in: "date-time", out: "time.Time"},
 	}
 
 	for _, testCase := range testCases {
@@ -278,6 +283,73 @@ func TestFmtFieldName(t *testing.T) {
 		expected := testCase.out
 		if expected != actual {
 			t.Fatalf("error FmtFieldName(): expected: %s | got: %s", expected, actual)
+		}
+	}
+}
+
+func TestGetImportKey(t *testing.T) {
+	t.Parallel()
+
+	type TestCase struct {
+		in  string
+		out string
+	}
+
+	testCases := []TestCase{
+		{in: "uri", out: ""},
+		{in: "date-time", out: "date-time"},
+	}
+
+	for _, testCase := range testCases {
+		schema := jsonschema.Schema{Format: &testCase.in}
+		actual := getCustomTypeKey(schema)
+		expected := testCase.out
+		if expected != actual {
+			t.Fatalf("error getImportKey(): expected: %s | got: %s", expected, actual)
+		}
+	}
+}
+
+func TestGetImportType(t *testing.T) {
+	t.Parallel()
+
+	type TestCase struct {
+		in  string
+		out string
+	}
+
+	testCases := []TestCase{
+		{in: "uri", out: ""},
+		{in: "date-time", out: "time.Time"},
+	}
+
+	for _, testCase := range testCases {
+		actual := getCustomType(testCase.in)
+		expected := testCase.out
+		if expected != actual {
+			t.Fatalf("error getImportType(): expected: %s | got: %s", expected, actual)
+		}
+	}
+}
+
+func TestHasImportKey(t *testing.T) {
+	t.Parallel()
+
+	type TestCase struct {
+		in  string
+		out bool
+	}
+
+	testCases := []TestCase{
+		{in: "uri", out: false},
+		{in: "date-time", out: true},
+	}
+
+	for _, testCase := range testCases {
+		actual := hasCustomType(testCase.in)
+		expected := testCase.out
+		if expected != actual {
+			t.Fatalf("error hasImportKey(): expected: %t | got: %t", expected, actual)
 		}
 	}
 }

--- a/src/internal/generate/generate_utils_test.go
+++ b/src/internal/generate/generate_utils_test.go
@@ -123,7 +123,7 @@ func TestGetJsonType(t *testing.T) {
 
 		expected := "object"
 
-		actual := getJsonType(*schemaWithSimpleType)
+		actual := getJsonOrCustomType(*schemaWithSimpleType)
 
 		if actual != expected {
 			t.Errorf("expected %s, got %s", expected, actual)
@@ -135,7 +135,7 @@ func TestGetJsonType(t *testing.T) {
 		schemaWithNoSimpleType := schema.OneOf[0].TypeObject // This schema has no type
 		expected := ""
 
-		actual := getJsonType(*schemaWithNoSimpleType)
+		actual := getJsonOrCustomType(*schemaWithNoSimpleType)
 
 		if actual != expected {
 			t.Errorf("expected %s, got %s", expected, actual)
@@ -162,7 +162,7 @@ func TestIsPrimitiveJsonType(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual := isPrimitiveJsonType(testCase.in)
+		actual := isPrimitiveOrCustomJsonType(testCase.in)
 		expected := testCase.out
 		if expected != actual {
 			t.Errorf("error isPrimitiveJsonType(): expected: %t | got: %t", expected, actual)
@@ -287,7 +287,7 @@ func TestFmtFieldName(t *testing.T) {
 	}
 }
 
-func TestGetImportKey(t *testing.T) {
+func TestGetCustomTypeKey(t *testing.T) {
 	t.Parallel()
 
 	type TestCase struct {
@@ -306,50 +306,6 @@ func TestGetImportKey(t *testing.T) {
 		expected := testCase.out
 		if expected != actual {
 			t.Fatalf("error getImportKey(): expected: %s | got: %s", expected, actual)
-		}
-	}
-}
-
-func TestGetImportType(t *testing.T) {
-	t.Parallel()
-
-	type TestCase struct {
-		in  string
-		out string
-	}
-
-	testCases := []TestCase{
-		{in: "uri", out: ""},
-		{in: "date-time", out: "time.Time"},
-	}
-
-	for _, testCase := range testCases {
-		actual := getCustomType(testCase.in)
-		expected := testCase.out
-		if expected != actual {
-			t.Fatalf("error getImportType(): expected: %s | got: %s", expected, actual)
-		}
-	}
-}
-
-func TestHasImportKey(t *testing.T) {
-	t.Parallel()
-
-	type TestCase struct {
-		in  string
-		out bool
-	}
-
-	testCases := []TestCase{
-		{in: "uri", out: false},
-		{in: "date-time", out: true},
-	}
-
-	for _, testCase := range testCases {
-		actual := hasCustomType(testCase.in)
-		expected := testCase.out
-		if expected != actual {
-			t.Fatalf("error hasImportKey(): expected: %t | got: %t", expected, actual)
 		}
 	}
 }

--- a/src/types/oscal-1-0-4/types.go
+++ b/src/types/oscal-1-0-4/types.go
@@ -15,6 +15,10 @@ Source: https://github.com/defenseunicorns/go-oscal
 */
 package oscalTypes_1_0_4
 
+import (
+	"time"
+)
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
@@ -133,13 +137,13 @@ type LocalDefinitions struct {
 
 type Metadata struct {
 	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
-	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	LastModified       time.Time          `json:"last-modified" yaml:"last-modified"`
 	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
 	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
 	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
 	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
-	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	Published          time.Time          `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
 	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
@@ -186,7 +190,7 @@ type Result struct {
 	AssessmentLog    AssessmentLog           `json:"assessment-log,omitempty" yaml:"assessment-log,omitempty"`
 	Attestations     []AttestationStatements `json:"attestations,omitempty" yaml:"attestations,omitempty"`
 	Description      string                  `json:"description" yaml:"description"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Findings         []Finding               `json:"findings,omitempty" yaml:"findings,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LocalDefinitions LocalDefinitions        `json:"local-definitions,omitempty" yaml:"local-definitions,omitempty"`
@@ -195,7 +199,7 @@ type Result struct {
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ReviewedControls ReviewedControls        `json:"reviewed-controls" yaml:"reviewed-controls"`
 	Risks            []Risk                  `json:"risks,omitempty" yaml:"risks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	Title            string                  `json:"title" yaml:"title"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`
 }
@@ -274,9 +278,9 @@ type PlanOfActionAndMilestonesLocalDefinitions struct {
 }
 
 type Observation struct {
-	Collected        string             `json:"collected" yaml:"collected"`
+	Collected        time.Time          `json:"collected" yaml:"collected"`
 	Description      string             `json:"description" yaml:"description"`
-	Expires          string             `json:"expires,omitempty" yaml:"expires,omitempty"`
+	Expires          time.Time          `json:"expires,omitempty" yaml:"expires,omitempty"`
 	Links            []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Methods          []string           `json:"methods" yaml:"methods"`
 	Origins          []Origin           `json:"origins,omitempty" yaml:"origins,omitempty"`
@@ -303,7 +307,7 @@ type PoamItem struct {
 
 type Risk struct {
 	Characterizations   []Characterization   `json:"characterizations,omitempty" yaml:"characterizations,omitempty"`
-	Deadline            string               `json:"deadline,omitempty" yaml:"deadline,omitempty"`
+	Deadline            time.Time            `json:"deadline,omitempty" yaml:"deadline,omitempty"`
 	Description         string               `json:"description" yaml:"description"`
 	Links               []Link               `json:"links,omitempty" yaml:"links,omitempty"`
 	MitigatingFactors   []MitigatingFactor   `json:"mitigating-factors,omitempty" yaml:"mitigating-factors,omitempty"`
@@ -529,11 +533,11 @@ type ResponsibleParty struct {
 }
 
 type Revision struct {
-	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	LastModified time.Time  `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
 	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
 	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
 	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
-	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Published    time.Time  `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
 	Version      string     `json:"version" yaml:"version"`
@@ -949,23 +953,23 @@ type FrequencyCondition struct {
 }
 
 type OnDateCondition struct {
-	Date string `json:"date" yaml:"date"`
+	Date time.Time `json:"date" yaml:"date"`
 }
 
 type OnDateRangeCondition struct {
-	End   string `json:"end" yaml:"end"`
-	Start string `json:"start" yaml:"start"`
+	End   time.Time `json:"end" yaml:"end"`
+	Start time.Time `json:"start" yaml:"start"`
 }
 
 type AssessmentLogEntry struct {
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	End          string        `json:"end,omitempty" yaml:"end,omitempty"`
+	End          time.Time     `json:"end,omitempty" yaml:"end,omitempty"`
 	Links        []Link        `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy     []LoggedBy    `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props        []Property    `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedTasks []RelatedTask `json:"related-tasks,omitempty" yaml:"related-tasks,omitempty"`
 	Remarks      string        `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start        string        `json:"start" yaml:"start"`
+	Start        time.Time     `json:"start" yaml:"start"`
 	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID         string        `json:"uuid" yaml:"uuid"`
 }
@@ -1044,13 +1048,13 @@ type RequiredAsset struct {
 
 type RiskLogEntry struct {
 	Description      string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy         []LoggedBy              `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props            []Property              `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedResponses []RiskResponseReference `json:"related-responses,omitempty" yaml:"related-responses,omitempty"`
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	StatusChange     string                  `json:"status-change,omitempty" yaml:"status-change,omitempty"`
 	Title            string                  `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`

--- a/src/types/oscal-1-0-5/types.go
+++ b/src/types/oscal-1-0-5/types.go
@@ -15,6 +15,10 @@ Source: https://github.com/defenseunicorns/go-oscal
 */
 package oscalTypes_1_0_5
 
+import (
+	"time"
+)
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
@@ -133,13 +137,13 @@ type LocalDefinitions struct {
 
 type Metadata struct {
 	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
-	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	LastModified       time.Time          `json:"last-modified" yaml:"last-modified"`
 	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
 	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
 	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
 	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
-	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	Published          time.Time          `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
 	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
@@ -186,7 +190,7 @@ type Result struct {
 	AssessmentLog    AssessmentLog           `json:"assessment-log,omitempty" yaml:"assessment-log,omitempty"`
 	Attestations     []AttestationStatements `json:"attestations,omitempty" yaml:"attestations,omitempty"`
 	Description      string                  `json:"description" yaml:"description"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Findings         []Finding               `json:"findings,omitempty" yaml:"findings,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LocalDefinitions LocalDefinitions        `json:"local-definitions,omitempty" yaml:"local-definitions,omitempty"`
@@ -195,7 +199,7 @@ type Result struct {
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ReviewedControls ReviewedControls        `json:"reviewed-controls" yaml:"reviewed-controls"`
 	Risks            []Risk                  `json:"risks,omitempty" yaml:"risks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	Title            string                  `json:"title" yaml:"title"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`
 }
@@ -274,9 +278,9 @@ type PlanOfActionAndMilestonesLocalDefinitions struct {
 }
 
 type Observation struct {
-	Collected        string             `json:"collected" yaml:"collected"`
+	Collected        time.Time          `json:"collected" yaml:"collected"`
 	Description      string             `json:"description" yaml:"description"`
-	Expires          string             `json:"expires,omitempty" yaml:"expires,omitempty"`
+	Expires          time.Time          `json:"expires,omitempty" yaml:"expires,omitempty"`
 	Links            []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Methods          []string           `json:"methods" yaml:"methods"`
 	Origins          []Origin           `json:"origins,omitempty" yaml:"origins,omitempty"`
@@ -303,7 +307,7 @@ type PoamItem struct {
 
 type Risk struct {
 	Characterizations   []Characterization   `json:"characterizations,omitempty" yaml:"characterizations,omitempty"`
-	Deadline            string               `json:"deadline,omitempty" yaml:"deadline,omitempty"`
+	Deadline            time.Time            `json:"deadline,omitempty" yaml:"deadline,omitempty"`
 	Description         string               `json:"description" yaml:"description"`
 	Links               []Link               `json:"links,omitempty" yaml:"links,omitempty"`
 	MitigatingFactors   []MitigatingFactor   `json:"mitigating-factors,omitempty" yaml:"mitigating-factors,omitempty"`
@@ -529,11 +533,11 @@ type ResponsibleParty struct {
 }
 
 type Revision struct {
-	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	LastModified time.Time  `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
 	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
 	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
 	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
-	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Published    time.Time  `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
 	Version      string     `json:"version" yaml:"version"`
@@ -949,23 +953,23 @@ type FrequencyCondition struct {
 }
 
 type OnDateCondition struct {
-	Date string `json:"date" yaml:"date"`
+	Date time.Time `json:"date" yaml:"date"`
 }
 
 type OnDateRangeCondition struct {
-	End   string `json:"end" yaml:"end"`
-	Start string `json:"start" yaml:"start"`
+	End   time.Time `json:"end" yaml:"end"`
+	Start time.Time `json:"start" yaml:"start"`
 }
 
 type AssessmentLogEntry struct {
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	End          string        `json:"end,omitempty" yaml:"end,omitempty"`
+	End          time.Time     `json:"end,omitempty" yaml:"end,omitempty"`
 	Links        []Link        `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy     []LoggedBy    `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props        []Property    `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedTasks []RelatedTask `json:"related-tasks,omitempty" yaml:"related-tasks,omitempty"`
 	Remarks      string        `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start        string        `json:"start" yaml:"start"`
+	Start        time.Time     `json:"start" yaml:"start"`
 	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID         string        `json:"uuid" yaml:"uuid"`
 }
@@ -1044,13 +1048,13 @@ type RequiredAsset struct {
 
 type RiskLogEntry struct {
 	Description      string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy         []LoggedBy              `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props            []Property              `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedResponses []RiskResponseReference `json:"related-responses,omitempty" yaml:"related-responses,omitempty"`
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	StatusChange     string                  `json:"status-change,omitempty" yaml:"status-change,omitempty"`
 	Title            string                  `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`

--- a/src/types/oscal-1-0-6/types.go
+++ b/src/types/oscal-1-0-6/types.go
@@ -15,6 +15,10 @@ Source: https://github.com/defenseunicorns/go-oscal
 */
 package oscalTypes_1_0_6
 
+import (
+	"time"
+)
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
@@ -133,13 +137,13 @@ type LocalDefinitions struct {
 
 type Metadata struct {
 	DocumentIds        []DocumentId       `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
-	LastModified       string             `json:"last-modified" yaml:"last-modified"`
+	LastModified       time.Time          `json:"last-modified" yaml:"last-modified"`
 	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Locations          []Location         `json:"locations,omitempty" yaml:"locations,omitempty"`
 	OscalVersion       string             `json:"oscal-version" yaml:"oscal-version"`
 	Parties            []Party            `json:"parties,omitempty" yaml:"parties,omitempty"`
 	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
-	Published          string             `json:"published,omitempty" yaml:"published,omitempty"`
+	Published          time.Time          `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ResponsibleParties []ResponsibleParty `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
 	Revisions          []Revision         `json:"revisions,omitempty" yaml:"revisions,omitempty"`
@@ -186,7 +190,7 @@ type Result struct {
 	AssessmentLog    AssessmentLog           `json:"assessment-log,omitempty" yaml:"assessment-log,omitempty"`
 	Attestations     []AttestationStatements `json:"attestations,omitempty" yaml:"attestations,omitempty"`
 	Description      string                  `json:"description" yaml:"description"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Findings         []Finding               `json:"findings,omitempty" yaml:"findings,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LocalDefinitions LocalDefinitions        `json:"local-definitions,omitempty" yaml:"local-definitions,omitempty"`
@@ -195,7 +199,7 @@ type Result struct {
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ReviewedControls ReviewedControls        `json:"reviewed-controls" yaml:"reviewed-controls"`
 	Risks            []Risk                  `json:"risks,omitempty" yaml:"risks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	Title            string                  `json:"title" yaml:"title"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`
 }
@@ -274,9 +278,9 @@ type PlanOfActionAndMilestonesLocalDefinitions struct {
 }
 
 type Observation struct {
-	Collected        string             `json:"collected" yaml:"collected"`
+	Collected        time.Time          `json:"collected" yaml:"collected"`
 	Description      string             `json:"description" yaml:"description"`
-	Expires          string             `json:"expires,omitempty" yaml:"expires,omitempty"`
+	Expires          time.Time          `json:"expires,omitempty" yaml:"expires,omitempty"`
 	Links            []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Methods          []string           `json:"methods" yaml:"methods"`
 	Origins          []Origin           `json:"origins,omitempty" yaml:"origins,omitempty"`
@@ -303,7 +307,7 @@ type PoamItem struct {
 
 type Risk struct {
 	Characterizations   []Characterization   `json:"characterizations,omitempty" yaml:"characterizations,omitempty"`
-	Deadline            string               `json:"deadline,omitempty" yaml:"deadline,omitempty"`
+	Deadline            time.Time            `json:"deadline,omitempty" yaml:"deadline,omitempty"`
 	Description         string               `json:"description" yaml:"description"`
 	Links               []Link               `json:"links,omitempty" yaml:"links,omitempty"`
 	MitigatingFactors   []MitigatingFactor   `json:"mitigating-factors,omitempty" yaml:"mitigating-factors,omitempty"`
@@ -529,11 +533,11 @@ type ResponsibleParty struct {
 }
 
 type Revision struct {
-	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	LastModified time.Time  `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
 	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
 	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
 	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
-	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Published    time.Time  `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
 	Version      string     `json:"version" yaml:"version"`
@@ -949,23 +953,23 @@ type FrequencyCondition struct {
 }
 
 type OnDateCondition struct {
-	Date string `json:"date" yaml:"date"`
+	Date time.Time `json:"date" yaml:"date"`
 }
 
 type OnDateRangeCondition struct {
-	End   string `json:"end" yaml:"end"`
-	Start string `json:"start" yaml:"start"`
+	End   time.Time `json:"end" yaml:"end"`
+	Start time.Time `json:"start" yaml:"start"`
 }
 
 type AssessmentLogEntry struct {
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	End          string        `json:"end,omitempty" yaml:"end,omitempty"`
+	End          time.Time     `json:"end,omitempty" yaml:"end,omitempty"`
 	Links        []Link        `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy     []LoggedBy    `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props        []Property    `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedTasks []RelatedTask `json:"related-tasks,omitempty" yaml:"related-tasks,omitempty"`
 	Remarks      string        `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start        string        `json:"start" yaml:"start"`
+	Start        time.Time     `json:"start" yaml:"start"`
 	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID         string        `json:"uuid" yaml:"uuid"`
 }
@@ -1044,13 +1048,13 @@ type RequiredAsset struct {
 
 type RiskLogEntry struct {
 	Description      string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy         []LoggedBy              `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props            []Property              `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedResponses []RiskResponseReference `json:"related-responses,omitempty" yaml:"related-responses,omitempty"`
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	StatusChange     string                  `json:"status-change,omitempty" yaml:"status-change,omitempty"`
 	Title            string                  `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`

--- a/src/types/oscal-1-1-0/types.go
+++ b/src/types/oscal-1-1-0/types.go
@@ -15,6 +15,10 @@ Source: https://github.com/defenseunicorns/go-oscal
 */
 package oscalTypes_1_1_0
 
+import (
+	"time"
+)
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
@@ -135,13 +139,13 @@ type LocalDefinitions struct {
 type Metadata struct {
 	Actions            []Action               `json:"actions,omitempty" yaml:"actions,omitempty"`
 	DocumentIds        []DocumentId           `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
-	LastModified       string                 `json:"last-modified" yaml:"last-modified"`
+	LastModified       time.Time              `json:"last-modified" yaml:"last-modified"`
 	Links              []Link                 `json:"links,omitempty" yaml:"links,omitempty"`
 	Locations          []Location             `json:"locations,omitempty" yaml:"locations,omitempty"`
 	OscalVersion       string                 `json:"oscal-version" yaml:"oscal-version"`
 	Parties            []Party                `json:"parties,omitempty" yaml:"parties,omitempty"`
 	Props              []Property             `json:"props,omitempty" yaml:"props,omitempty"`
-	Published          string                 `json:"published,omitempty" yaml:"published,omitempty"`
+	Published          time.Time              `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks            string                 `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ResponsibleParties []ResponsibleParty     `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
 	Revisions          []RevisionHistoryEntry `json:"revisions,omitempty" yaml:"revisions,omitempty"`
@@ -188,7 +192,7 @@ type Result struct {
 	AssessmentLog    AssessmentLog           `json:"assessment-log,omitempty" yaml:"assessment-log,omitempty"`
 	Attestations     []AttestationStatements `json:"attestations,omitempty" yaml:"attestations,omitempty"`
 	Description      string                  `json:"description" yaml:"description"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Findings         []Finding               `json:"findings,omitempty" yaml:"findings,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LocalDefinitions LocalDefinitions        `json:"local-definitions,omitempty" yaml:"local-definitions,omitempty"`
@@ -197,7 +201,7 @@ type Result struct {
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ReviewedControls ReviewedControls        `json:"reviewed-controls" yaml:"reviewed-controls"`
 	Risks            []Risk                  `json:"risks,omitempty" yaml:"risks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	Title            string                  `json:"title" yaml:"title"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`
 }
@@ -291,9 +295,9 @@ type PlanOfActionAndMilestonesLocalDefinitions struct {
 }
 
 type Observation struct {
-	Collected        string             `json:"collected" yaml:"collected"`
+	Collected        time.Time          `json:"collected" yaml:"collected"`
 	Description      string             `json:"description" yaml:"description"`
-	Expires          string             `json:"expires,omitempty" yaml:"expires,omitempty"`
+	Expires          time.Time          `json:"expires,omitempty" yaml:"expires,omitempty"`
 	Links            []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Methods          []string           `json:"methods" yaml:"methods"`
 	Origins          []Origin           `json:"origins,omitempty" yaml:"origins,omitempty"`
@@ -321,7 +325,7 @@ type PoamItem struct {
 
 type Risk struct {
 	Characterizations   []Characterization   `json:"characterizations,omitempty" yaml:"characterizations,omitempty"`
-	Deadline            string               `json:"deadline,omitempty" yaml:"deadline,omitempty"`
+	Deadline            time.Time            `json:"deadline,omitempty" yaml:"deadline,omitempty"`
 	Description         string               `json:"description" yaml:"description"`
 	Links               []Link               `json:"links,omitempty" yaml:"links,omitempty"`
 	MitigatingFactors   []MitigatingFactor   `json:"mitigating-factors,omitempty" yaml:"mitigating-factors,omitempty"`
@@ -508,7 +512,7 @@ type SystemUser struct {
 }
 
 type Action struct {
-	Date               string             `json:"date,omitempty" yaml:"date,omitempty"`
+	Date               time.Time          `json:"date,omitempty" yaml:"date,omitempty"`
 	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
 	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
@@ -560,11 +564,11 @@ type ResponsibleParty struct {
 }
 
 type RevisionHistoryEntry struct {
-	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	LastModified time.Time  `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
 	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
 	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
 	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
-	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Published    time.Time  `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
 	Version      string     `json:"version" yaml:"version"`
@@ -982,23 +986,23 @@ type FrequencyCondition struct {
 }
 
 type OnDateCondition struct {
-	Date string `json:"date" yaml:"date"`
+	Date time.Time `json:"date" yaml:"date"`
 }
 
 type OnDateRangeCondition struct {
-	End   string `json:"end" yaml:"end"`
-	Start string `json:"start" yaml:"start"`
+	End   time.Time `json:"end" yaml:"end"`
+	Start time.Time `json:"start" yaml:"start"`
 }
 
 type AssessmentLogEntry struct {
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	End          string        `json:"end,omitempty" yaml:"end,omitempty"`
+	End          time.Time     `json:"end,omitempty" yaml:"end,omitempty"`
 	Links        []Link        `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy     []LoggedBy    `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props        []Property    `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedTasks []RelatedTask `json:"related-tasks,omitempty" yaml:"related-tasks,omitempty"`
 	Remarks      string        `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start        string        `json:"start" yaml:"start"`
+	Start        time.Time     `json:"start" yaml:"start"`
 	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID         string        `json:"uuid" yaml:"uuid"`
 }
@@ -1076,13 +1080,13 @@ type RequiredAsset struct {
 
 type RiskLogEntry struct {
 	Description      string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy         []LoggedBy              `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props            []Property              `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedResponses []RiskResponseReference `json:"related-responses,omitempty" yaml:"related-responses,omitempty"`
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	StatusChange     string                  `json:"status-change,omitempty" yaml:"status-change,omitempty"`
 	Title            string                  `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`

--- a/src/types/oscal-1-1-1/types.go
+++ b/src/types/oscal-1-1-1/types.go
@@ -15,6 +15,10 @@ Source: https://github.com/defenseunicorns/go-oscal
 */
 package oscalTypes_1_1_1
 
+import (
+	"time"
+)
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`
@@ -135,13 +139,13 @@ type LocalDefinitions struct {
 type Metadata struct {
 	Actions            []Action               `json:"actions,omitempty" yaml:"actions,omitempty"`
 	DocumentIds        []DocumentId           `json:"document-ids,omitempty" yaml:"document-ids,omitempty"`
-	LastModified       string                 `json:"last-modified" yaml:"last-modified"`
+	LastModified       time.Time              `json:"last-modified" yaml:"last-modified"`
 	Links              []Link                 `json:"links,omitempty" yaml:"links,omitempty"`
 	Locations          []Location             `json:"locations,omitempty" yaml:"locations,omitempty"`
 	OscalVersion       string                 `json:"oscal-version" yaml:"oscal-version"`
 	Parties            []Party                `json:"parties,omitempty" yaml:"parties,omitempty"`
 	Props              []Property             `json:"props,omitempty" yaml:"props,omitempty"`
-	Published          string                 `json:"published,omitempty" yaml:"published,omitempty"`
+	Published          time.Time              `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks            string                 `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ResponsibleParties []ResponsibleParty     `json:"responsible-parties,omitempty" yaml:"responsible-parties,omitempty"`
 	Revisions          []RevisionHistoryEntry `json:"revisions,omitempty" yaml:"revisions,omitempty"`
@@ -188,7 +192,7 @@ type Result struct {
 	AssessmentLog    AssessmentLog           `json:"assessment-log,omitempty" yaml:"assessment-log,omitempty"`
 	Attestations     []AttestationStatements `json:"attestations,omitempty" yaml:"attestations,omitempty"`
 	Description      string                  `json:"description" yaml:"description"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Findings         []Finding               `json:"findings,omitempty" yaml:"findings,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LocalDefinitions LocalDefinitions        `json:"local-definitions,omitempty" yaml:"local-definitions,omitempty"`
@@ -197,7 +201,7 @@ type Result struct {
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	ReviewedControls ReviewedControls        `json:"reviewed-controls" yaml:"reviewed-controls"`
 	Risks            []Risk                  `json:"risks,omitempty" yaml:"risks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	Title            string                  `json:"title" yaml:"title"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`
 }
@@ -291,9 +295,9 @@ type PlanOfActionAndMilestonesLocalDefinitions struct {
 }
 
 type Observation struct {
-	Collected        string             `json:"collected" yaml:"collected"`
+	Collected        time.Time          `json:"collected" yaml:"collected"`
 	Description      string             `json:"description" yaml:"description"`
-	Expires          string             `json:"expires,omitempty" yaml:"expires,omitempty"`
+	Expires          time.Time          `json:"expires,omitempty" yaml:"expires,omitempty"`
 	Links            []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Methods          []string           `json:"methods" yaml:"methods"`
 	Origins          []Origin           `json:"origins,omitempty" yaml:"origins,omitempty"`
@@ -321,7 +325,7 @@ type PoamItem struct {
 
 type Risk struct {
 	Characterizations   []Characterization   `json:"characterizations,omitempty" yaml:"characterizations,omitempty"`
-	Deadline            string               `json:"deadline,omitempty" yaml:"deadline,omitempty"`
+	Deadline            time.Time            `json:"deadline,omitempty" yaml:"deadline,omitempty"`
 	Description         string               `json:"description" yaml:"description"`
 	Links               []Link               `json:"links,omitempty" yaml:"links,omitempty"`
 	MitigatingFactors   []MitigatingFactor   `json:"mitigating-factors,omitempty" yaml:"mitigating-factors,omitempty"`
@@ -508,7 +512,7 @@ type SystemUser struct {
 }
 
 type Action struct {
-	Date               string             `json:"date,omitempty" yaml:"date,omitempty"`
+	Date               time.Time          `json:"date,omitempty" yaml:"date,omitempty"`
 	Links              []Link             `json:"links,omitempty" yaml:"links,omitempty"`
 	Props              []Property         `json:"props,omitempty" yaml:"props,omitempty"`
 	Remarks            string             `json:"remarks,omitempty" yaml:"remarks,omitempty"`
@@ -560,11 +564,11 @@ type ResponsibleParty struct {
 }
 
 type RevisionHistoryEntry struct {
-	LastModified string     `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
+	LastModified time.Time  `json:"last-modified,omitempty" yaml:"last-modified,omitempty"`
 	Links        []Link     `json:"links,omitempty" yaml:"links,omitempty"`
 	OscalVersion string     `json:"oscal-version,omitempty" yaml:"oscal-version,omitempty"`
 	Props        []Property `json:"props,omitempty" yaml:"props,omitempty"`
-	Published    string     `json:"published,omitempty" yaml:"published,omitempty"`
+	Published    time.Time  `json:"published,omitempty" yaml:"published,omitempty"`
 	Remarks      string     `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 	Title        string     `json:"title,omitempty" yaml:"title,omitempty"`
 	Version      string     `json:"version" yaml:"version"`
@@ -982,23 +986,23 @@ type FrequencyCondition struct {
 }
 
 type OnDateCondition struct {
-	Date string `json:"date" yaml:"date"`
+	Date time.Time `json:"date" yaml:"date"`
 }
 
 type OnDateRangeCondition struct {
-	End   string `json:"end" yaml:"end"`
-	Start string `json:"start" yaml:"start"`
+	End   time.Time `json:"end" yaml:"end"`
+	Start time.Time `json:"start" yaml:"start"`
 }
 
 type AssessmentLogEntry struct {
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	End          string        `json:"end,omitempty" yaml:"end,omitempty"`
+	End          time.Time     `json:"end,omitempty" yaml:"end,omitempty"`
 	Links        []Link        `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy     []LoggedBy    `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props        []Property    `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedTasks []RelatedTask `json:"related-tasks,omitempty" yaml:"related-tasks,omitempty"`
 	Remarks      string        `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start        string        `json:"start" yaml:"start"`
+	Start        time.Time     `json:"start" yaml:"start"`
 	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID         string        `json:"uuid" yaml:"uuid"`
 }
@@ -1076,13 +1080,13 @@ type RequiredAsset struct {
 
 type RiskLogEntry struct {
 	Description      string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	End              string                  `json:"end,omitempty" yaml:"end,omitempty"`
+	End              time.Time               `json:"end,omitempty" yaml:"end,omitempty"`
 	Links            []Link                  `json:"links,omitempty" yaml:"links,omitempty"`
 	LoggedBy         []LoggedBy              `json:"logged-by,omitempty" yaml:"logged-by,omitempty"`
 	Props            []Property              `json:"props,omitempty" yaml:"props,omitempty"`
 	RelatedResponses []RiskResponseReference `json:"related-responses,omitempty" yaml:"related-responses,omitempty"`
 	Remarks          string                  `json:"remarks,omitempty" yaml:"remarks,omitempty"`
-	Start            string                  `json:"start" yaml:"start"`
+	Start            time.Time               `json:"start" yaml:"start"`
 	StatusChange     string                  `json:"status-change,omitempty" yaml:"status-change,omitempty"`
 	Title            string                  `json:"title,omitempty" yaml:"title,omitempty"`
 	UUID             string                  `json:"uuid" yaml:"uuid"`


### PR DESCRIPTION
Added the ability to set custom types. Right now those custom types are defined and set by using the format field and adding the custom type and return type to the PrimitiveAndCustomTypes map. The only currently supported custom type is the `date-time` format that relates to the `time.Time` type. 

Added the ability to use imports. Currently the only import is `time` 