### PR TITLE
#148. Update GetTimeStamp to return time.Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - yyyy-mm-dd
+# [unreleased] - yyyy-mm-dd
+
+### Fix
+
+- utils/timestamp.GetTimeStamp now returns `time.Now()` as type `time.Time` in accordance with the changes to oscalTypes. 
+  - `time.Time` is marshalled and unmarshalled to rfc3339 by default in compliance with the oscal complete schema expected timestamp format. 
+
+# v0.2.0 - 2024-02-29
 
 ### Added
-
-- `doctor` command to prep new oscal_complete_schema.json from [OSCAL Releases](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.2) for use in the `validate` and `revise` commands. Behavior ported from [oscal-json-doctor](https://github.com/defenseunicorns/oscal-json-doctor) in order to keep all needed functionality within the go-oscal repo.
+- OSCAL 1.1.2 types
+  - Validation and Revision now supported for OSCAL 1.1.2
+- `doctor` command to prep new oscal_complete_schema.json from [OSCAL Releases](https://github.com/usnistgov/OSCAL/releases/tag/v1.1.2) for use in the `validate` and `revise` commands. Behavior ported from [oscal-json-doctor](https://github.com/defenseunicorns/oscal-json-doctor) in order to keep all needed functionality within the go-oscal repo. Create to fix https://github.com/usnistgov/OSCAL/issues/1908 and https://github.com/usnistgov/OSCAL/issues/1908
 - documentation for `generate` and `doctor` commands
 - documentation for upgrading to a new version of OSCAL (docs/upgrading-oscal-version.md)
 - Added support for custom types.

--- a/src/internal/utils/timestamp.go
+++ b/src/internal/utils/timestamp.go
@@ -2,6 +2,7 @@ package utils
 
 import "time"
 
-func GetTimestamp() string {
-	return time.Now().Format(time.RFC3339)
+func GetTimestamp() time.Time {
+	// Defaults RFC3339 when marshalling and unmarshalling
+	return time.Now()
 }

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"time"
+
 	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
 	"github.com/defenseunicorns/go-oscal/src/internal/utils"
 )
@@ -177,11 +179,16 @@ func TestVersionUtils(t *testing.T) {
 
 		t.Run("updates the last modified field", func(t *testing.T) {
 			t.Parallel()
+
+			initTime, error := time.Parse(time.RFC3339, "2020-09-09T00:00:00Z")
+			if error != nil {
+				t.Errorf("expected no error, got %v", error)
+			}
 			metadata := map[string]interface{}{
-				"last-modified": "2020-09-09T00:00:00Z",
+				"last-modified": initTime,
 			}
 			utils.UpdateLastModified(metadata)
-			if metadata["last-modified"] == "2020-09-09T00:00:00Z" {
+			if metadata["last-modified"].(time.Time).Format(time.RFC3339) == initTime.Format(time.RFC3339) {
 				t.Errorf("expected last-modified to be updated")
 			}
 		})


### PR DESCRIPTION
Now that type generation uses time.Time instead of string for the timestamps, when revising to another version the timestamp should be updated to reflect the type changes. 