### PR TITLE
#147. Validate-upgrade-notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # [unreleased] - yyyy-mm-dd
 
+
+# v0.2.1 - 2024-03-01
+
 ### Fix
 
 - utils/timestamp.GetTimeStamp now returns `time.Now()` as type `time.Time` in accordance with the changes to oscalTypes. 

--- a/renovate.json
+++ b/renovate.json
@@ -1,33 +1,62 @@
 {
-  "extends": ["config:recommended"],
-  "ignorePaths": ["**/adr/**", "**/docs/**", "**/test/**"],
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "**/adr/**",
+    "**/docs/**",
+    "**/test/**"
+  ],
   "timezone": "America/New_York",
-  "schedule": ["after 12pm every weekday", "before 11am every weekday"],
+  "schedule": [
+    "after 12pm every weekday",
+    "before 11am every weekday"
+  ],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true,
       "automergeType": "pr"
     },
     {
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
       "automerge": true,
       "automergeType": "pr"
     }
   ],
   "platformAutomerge": true,
   "platformCommit": true,
-  "postUpdateOptions": ["gomodTidy"],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "commitBodyTable": true,
   "commitMessagePrefix": "deps",
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^update/oscal-version\\.yaml$"],
-      "matchStrings": ["oscal: v(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "fileMatch": [
+        "^update/oscal-version\\.yaml$",
+        "^src/internal/utils/version\\.go$"
+      ],
+      "matchStrings": [
+        "oscal: v(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "latestVersion = (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "usnistgov/OSCAL"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^src/internal/utils/version\\.go$"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
       ],
       "matchStrings": [
         "oscal: v(?<currentValue>\\d+\\.\\d+\\.\\d+)",
-        "latestVersion = (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "\\s*latestVersion = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "usnistgov/OSCAL"

--- a/src/cmd/revise/revise.go
+++ b/src/cmd/revise/revise.go
@@ -110,12 +110,18 @@ func Revise(opts *ReviseOptions) (reviser revision.Reviser, err error) {
 		return reviser, fmt.Errorf("Failed to create reviser: %s\n", err)
 	}
 
+	version := reviser.GetSchemaVersion()
+	err = utils.VersionWarning(version)
+	if err != nil {
+		log.Print(err)
+	}
+
 	reviser.SetDocumentPath(opts.InputFile)
 
 	// Run the upgrade
 	err = reviser.Revise()
 	if err != nil {
-		return reviser, fmt.Errorf("Failed to upgrade %s version %s: %s\n", reviser.GetModelType(), reviser.GetSchemaVersion(), err)
+		return reviser, fmt.Errorf("failed to upgrade %s version %s: %s", reviser.GetModelType(), reviser.GetSchemaVersion(), err)
 	}
 
 	return reviser, nil

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/defenseunicorns/go-oscal/src/internal/utils"
 	"github.com/defenseunicorns/go-oscal/src/pkg/validation"
 	"github.com/spf13/cobra"
 )
@@ -44,30 +45,36 @@ var ValidateCmd = &cobra.Command{
 func ValidateCommand(inputFile string) (validator validation.Validator, err error) {
 	// Validate the input file
 	if inputFile == "" {
-		return validator, errors.New("Please specify an input file with the -f flag")
+		return validator, errors.New("please specify an input file with the -f flag")
 	}
 
 	// Validate the input file is a json or yaml file
 	if !strings.HasSuffix(inputFile, "json") && !strings.HasSuffix(inputFile, "yaml") {
-		return validator, errors.New("Please specify a json or yaml file")
+		return validator, errors.New("please specify a json or yaml file")
 	}
 
 	// Read the input file
 	bytes, err := os.ReadFile(inputFile)
 	if err != nil {
-		return validator, fmt.Errorf("reading input file: %s\n", err)
+		return validator, fmt.Errorf("reading input file: %s", err)
 	}
 
 	validator, err = validation.NewValidator(bytes)
 	if err != nil {
-		return validator, fmt.Errorf("Failed to create validator: %s\n", err)
+		return validator, fmt.Errorf("failed to create validator: %s", err)
+	}
+
+	version := validator.GetSchemaVersion()
+	err = utils.VersionWarning(version)
+	if err != nil {
+		log.Print(err)
 	}
 
 	validator.SetDocumentPath(inputFile)
 
 	err = validator.Validate()
 	if err != nil {
-		return validator, fmt.Errorf("Failed to validate %s version %s: %s\n", validator.GetModelType(), validator.GetSchemaVersion(), err)
+		return validator, fmt.Errorf("failed to validate %s version %s: %s", validator.GetModelType(), validator.GetSchemaVersion(), err)
 	}
 
 	return validator, nil

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -164,7 +164,7 @@ func UpdateLastModified(metadata map[string]interface{}) {
 	metadata["last-modified"] = GetTimestamp()
 }
 
-// VersionWarning prints a warning if the version is has known issues.
+// VersionWarning prints a warning if the version is has known issues or the version is not the latest.
 func VersionWarning(version string) {
 	latestVersion, _ := GetLatestVersion()
 	switch version {

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"reflect"
 	"regexp"
@@ -162,17 +161,4 @@ func ReplaceOscalVersionInMap(model map[string]interface{}, version string) (upg
 // UpdateLastModified updates the last-modified field in the metadata
 func UpdateLastModified(metadata map[string]interface{}) {
 	metadata["last-modified"] = GetTimestamp()
-}
-
-// VersionWarning prints a warning if the version is has known issues or the version is not the latest.
-func VersionWarning(version string) {
-	latestVersion, _ := GetLatestVersion()
-	switch version {
-	case "1.0.5":
-		log.Println("WARNING: 1.0.5 has known issues. Please upgrade to version 1.0.6 or higher.")
-	default:
-		if latestVersion != version {
-			log.Printf("WARNING: Currently using OSCAL version %s. The latest version is %s", version, latestVersion)
-		}
-	}
 }

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -172,7 +172,7 @@ func VersionWarning(version string) {
 		log.Println("WARNING: 1.0.5 has known issues. Please upgrade to version 1.0.6 or higher.")
 	default:
 		if latestVersion != version {
-			log.Printf("WARNING: Currently using OSCAL version %s. Please upgrade to version %s", version, latestVersion)
+			log.Printf("WARNING: Currently using OSCAL version %s. The latest version is %s", version, latestVersion)
 		}
 	}
 }

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -10,9 +10,12 @@ import (
 	"github.com/defenseunicorns/go-oscal/src/internal/schemas"
 )
 
+const (
+	latestVersion = "1.1.2"
+)
+
 var (
 	versionRegexp = regexp.MustCompile(`^\d+([-\.]\d+){2}$`)
-	latestVersion = "1.1.2"
 )
 
 // IsValidOscalVersion returns true if the version is supported, false if not.

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -166,11 +166,13 @@ func UpdateLastModified(metadata map[string]interface{}) {
 
 // VersionWarning prints a warning if the version is has known issues.
 func VersionWarning(version string) {
+	latestVersion, _ := GetLatestVersion()
 	switch version {
 	case "1.0.5":
 		log.Println("WARNING: 1.0.5 has known issues. Please upgrade to version 1.0.6 or higher.")
-		break
 	default:
-		return
+		if latestVersion != version {
+			log.Printf("WARNING: Currently using OSCAL version %s. Please upgrade to version %s", version, latestVersion)
+		}
 	}
 }

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -162,3 +162,20 @@ func ReplaceOscalVersionInMap(model map[string]interface{}, version string) (upg
 func UpdateLastModified(metadata map[string]interface{}) {
 	metadata["last-modified"] = GetTimestamp()
 }
+
+// VersionWarning returns an warning as an error if there are any known issues with the current version or it isn't the latest.
+func VersionWarning(version string) error {
+	latestVersion, err := GetLatestVersion()
+	if err != nil {
+		return err
+	}
+	switch version {
+	case "1.0.5":
+		return fmt.Errorf("WARNING: 1.0.5 has known issues. Please upgrade to version 1.0.6 or higher")
+	default:
+		if latestVersion != version {
+			return fmt.Errorf("WARNING: Currently using OSCAL version %s. The latest version is %s", version, latestVersion)
+		}
+	}
+	return nil
+}

--- a/src/internal/utils/version.go
+++ b/src/internal/utils/version.go
@@ -39,6 +39,8 @@ func validVersionFormat(version string) error {
 }
 
 // GetLatestVersion returns the latest version of the OSCAL schema from the schemas directory
+// Implemented to read and find the latest version of the OSCAL schema in order to allow for
+// New versions to be added without needing to update the code
 func GetLatestVersion() (latestVersion string, err error) {
 	// calcVersionVal is a helper function to calculate the version value
 	// by removing the dots and converting the version to an integer

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -1,14 +1,11 @@
 package utils_test
 
 import (
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"time"
 
-	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
 	"github.com/defenseunicorns/go-oscal/src/internal/utils"
 	"gopkg.in/yaml.v3"
 )
@@ -193,37 +190,6 @@ func TestVersionUtils(t *testing.T) {
 			utils.UpdateLastModified(metadata)
 			if metadata["last-modified"].(time.Time).Format(time.RFC3339) == initTime.Format(time.RFC3339) {
 				t.Errorf("expected last-modified to be updated")
-			}
-		})
-	})
-
-	t.Run("VersionWarning", func(t *testing.T) {
-		t.Parallel()
-		logBytes := gooscaltest.RedirectLog(t)
-
-		latestVersion, err := utils.GetLatestVersion()
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		t.Run("prints a warning if the version is has known issues", func(t *testing.T) {
-			utils.VersionWarning("1.0.5")
-			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), "WARNING: 1.0.5 has known issues.") {
-				t.Errorf("expected warning to be printed")
-			}
-		})
-
-		t.Run("prints a warning if not on the latest version", func(t *testing.T) {
-			utils.VersionWarning("1.0.6")
-			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", "1.0.6", latestVersion)) {
-				t.Errorf("expected warning to be printed")
-			}
-		})
-
-		t.Run("does not print a warning if on the latest version", func(t *testing.T) {
-			utils.VersionWarning(latestVersion)
-			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", latestVersion, latestVersion)) {
-				t.Errorf("expected no warning to be printed")
 			}
 		})
 	})

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -200,6 +201,11 @@ func TestVersionUtils(t *testing.T) {
 		t.Parallel()
 		logBytes := gooscaltest.RedirectLog(t)
 
+		latestVersion, err := utils.GetLatestVersion()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
 		t.Run("prints a warning if the version is has known issues", func(t *testing.T) {
 			utils.VersionWarning("1.0.5")
 			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), "WARNING: 1.0.5 has known issues.") {
@@ -207,10 +213,17 @@ func TestVersionUtils(t *testing.T) {
 			}
 		})
 
-		t.Run("does not print a warning if the version is does not have known issues", func(t *testing.T) {
+		t.Run("prints a warning if not on the latest version", func(t *testing.T) {
 			utils.VersionWarning("1.0.6")
-			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), "WARNING: 1.0.6 has known issues.") {
-				t.Errorf("expected warning not to be printed")
+			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: A new version of the OSCAL schema is available. Please upgrade to version %s", latestVersion)) {
+				t.Errorf("expected warning to be printed")
+			}
+		})
+
+		t.Run("does not print a warning if on the latest version", func(t *testing.T) {
+			utils.VersionWarning(latestVersion)
+			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: A new version of the OSCAL schema is available. Please upgrade to version %s", latestVersion)) {
+				t.Errorf("expected no warning to be printed")
 			}
 		})
 	})

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -197,10 +197,7 @@ func TestVersionUtils(t *testing.T) {
 	t.Run("VersionWarning", func(t *testing.T) {
 		t.Parallel()
 
-		latestVersion, err := utils.GetLatestVersion()
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
+		latestVersion := utils.GetLatestSupportedVersion()
 
 		t.Run("returns an error if the version is has known issues", func(t *testing.T) {
 			err := utils.VersionWarning("1.0.5")
@@ -225,6 +222,7 @@ func TestVersionUtils(t *testing.T) {
 	})
 }
 
+// Ensures continuity between the update/oscal-version.yaml file and the GetLatestSupportedVersion function
 func TestGetLatestVersion(t *testing.T) {
 	t.Parallel()
 	latestVersionPath := "../../../update/oscal-version.yaml"
@@ -246,10 +244,8 @@ func TestGetLatestVersion(t *testing.T) {
 
 	t.Run("returns the latest version", func(t *testing.T) {
 		t.Parallel()
-		latestVersion, err := utils.GetLatestVersion()
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
+		latestVersion := utils.GetLatestSupportedVersion()
+
 		if latestVersion != expected {
 			t.Errorf("expected %s, got %s", expected, latestVersion)
 		}

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -1,14 +1,11 @@
 package utils_test
 
 import (
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"time"
 
-	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
 	"github.com/defenseunicorns/go-oscal/src/internal/utils"
 	"gopkg.in/yaml.v3"
 )
@@ -199,31 +196,30 @@ func TestVersionUtils(t *testing.T) {
 
 	t.Run("VersionWarning", func(t *testing.T) {
 		t.Parallel()
-		logBytes := gooscaltest.RedirectLog(t)
 
 		latestVersion, err := utils.GetLatestVersion()
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 
-		t.Run("prints a warning if the version is has known issues", func(t *testing.T) {
-			utils.VersionWarning("1.0.5")
-			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), "WARNING: 1.0.5 has known issues.") {
-				t.Errorf("expected warning to be printed")
+		t.Run("returns an error if the version is has known issues", func(t *testing.T) {
+			err := utils.VersionWarning("1.0.5")
+			if err == nil {
+				t.Errorf("expected error, got %v", err)
 			}
 		})
 
-		t.Run("prints a warning if not on the latest version", func(t *testing.T) {
-			utils.VersionWarning("1.0.6")
-			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", "1.0.6", latestVersion)) {
-				t.Errorf("expected warning to be printed")
+		t.Run("returns an error if not on the latest version", func(t *testing.T) {
+			err := utils.VersionWarning("1.0.6")
+			if err == nil {
+				t.Errorf("expected error, got %v", err)
 			}
 		})
 
 		t.Run("does not print a warning if on the latest version", func(t *testing.T) {
-			utils.VersionWarning(latestVersion)
-			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", latestVersion, latestVersion)) {
-				t.Errorf("expected no warning to be printed")
+			err := utils.VersionWarning(latestVersion)
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
 			}
 		})
 	})

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
 	"github.com/defenseunicorns/go-oscal/src/internal/utils"
+	"gopkg.in/yaml.v3"
 )
 
 func TestVersionUtils(t *testing.T) {
@@ -212,4 +214,36 @@ func TestVersionUtils(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestGetLatestVersion(t *testing.T) {
+	t.Parallel()
+	latestVersionPath := "../../../update/oscal-version.yaml"
+
+	// Read the latest version from the file (updates from renovate PR when a new version of OSCAL is released)
+	bytes, err := os.ReadFile(latestVersionPath)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	// Unmarshal the latest version from the file
+	var updateVersion map[string]string
+	err = yaml.Unmarshal(bytes, &updateVersion)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	// Format the latest version
+	expected := utils.FormatOscalVersion(updateVersion["oscal"])
+
+	t.Run("returns the latest version", func(t *testing.T) {
+		t.Parallel()
+		latestVersion, err := utils.GetLatestVersion()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if latestVersion != expected {
+			t.Errorf("expected %s, got %s", expected, latestVersion)
+		}
+	})
+
 }

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -215,14 +215,14 @@ func TestVersionUtils(t *testing.T) {
 
 		t.Run("prints a warning if not on the latest version", func(t *testing.T) {
 			utils.VersionWarning("1.0.6")
-			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: A new version of the OSCAL schema is available. Please upgrade to version %s", latestVersion)) {
+			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", "1.0.6", latestVersion)) {
 				t.Errorf("expected warning to be printed")
 			}
 		})
 
 		t.Run("does not print a warning if on the latest version", func(t *testing.T) {
 			utils.VersionWarning(latestVersion)
-			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: A new version of the OSCAL schema is available. Please upgrade to version %s", latestVersion)) {
+			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", latestVersion, latestVersion)) {
 				t.Errorf("expected no warning to be printed")
 			}
 		})

--- a/src/internal/utils/version_test.go
+++ b/src/internal/utils/version_test.go
@@ -1,11 +1,14 @@
 package utils_test
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"time"
 
+	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
 	"github.com/defenseunicorns/go-oscal/src/internal/utils"
 	"gopkg.in/yaml.v3"
 )
@@ -190,6 +193,37 @@ func TestVersionUtils(t *testing.T) {
 			utils.UpdateLastModified(metadata)
 			if metadata["last-modified"].(time.Time).Format(time.RFC3339) == initTime.Format(time.RFC3339) {
 				t.Errorf("expected last-modified to be updated")
+			}
+		})
+	})
+
+	t.Run("VersionWarning", func(t *testing.T) {
+		t.Parallel()
+		logBytes := gooscaltest.RedirectLog(t)
+
+		latestVersion, err := utils.GetLatestVersion()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		t.Run("prints a warning if the version is has known issues", func(t *testing.T) {
+			utils.VersionWarning("1.0.5")
+			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), "WARNING: 1.0.5 has known issues.") {
+				t.Errorf("expected warning to be printed")
+			}
+		})
+
+		t.Run("prints a warning if not on the latest version", func(t *testing.T) {
+			utils.VersionWarning("1.0.6")
+			if !strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", "1.0.6", latestVersion)) {
+				t.Errorf("expected warning to be printed")
+			}
+		})
+
+		t.Run("does not print a warning if on the latest version", func(t *testing.T) {
+			utils.VersionWarning(latestVersion)
+			if strings.Contains(string(gooscaltest.ReadLog(t, logBytes)), fmt.Sprintf("WARNING: Currently using OSCAL version %s. The latest version is %s", latestVersion, latestVersion)) {
+				t.Errorf("expected no warning to be printed")
 			}
 		})
 	})

--- a/src/pkg/validation/validator.go
+++ b/src/pkg/validation/validator.go
@@ -103,10 +103,7 @@ func (v *Validator) GetValidationResult() (ValidationResult, error) {
 
 // IsLatestOscalVersion returns true if the model is the latest version of the OSCAL schema.
 func (v *Validator) IsLatestOscalVersion() (bool, error) {
-	latestVersion, err := utils.GetLatestVersion()
-	if err != nil {
-		return false, err
-	}
+	latestVersion := utils.GetLatestSupportedVersion()
 
 	version, err := utils.GetOscalVersionFromMap(v.jsonMap)
 	if err != nil {

--- a/src/pkg/validation/validator.go
+++ b/src/pkg/validation/validator.go
@@ -34,7 +34,6 @@ func NewValidator(oscalDoc utils.InterfaceOrBytes) (validator Validator, err err
 	if err != nil {
 		return validator, err
 	}
-	utils.VersionWarning(version)
 
 	return Validator{
 		jsonMap:       model,
@@ -56,7 +55,6 @@ func NewValidatorDesiredVersion(oscalDoc utils.InterfaceOrBytes, desiredVersion 
 	}
 
 	formattedVersion := utils.FormatOscalVersion(desiredVersion)
-	utils.VersionWarning(formattedVersion)
 
 	if err = utils.IsValidOscalVersion(formattedVersion); err != nil {
 		return validator, err
@@ -101,6 +99,21 @@ func (v *Validator) GetValidationResult() (ValidationResult, error) {
 		return v.validationResult, errors.New("validation has not been run")
 	}
 	return v.validationResult, nil
+}
+
+// IsLatestOscalVersion returns true if the model is the latest version of the OSCAL schema.
+func (v *Validator) IsLatestOscalVersion() (bool, error) {
+	latestVersion, err := utils.GetLatestVersion()
+	if err != nil {
+		return false, err
+	}
+
+	version, err := utils.GetOscalVersionFromMap(v.jsonMap)
+	if err != nil {
+		return false, err
+	}
+
+	return version == latestVersion, nil
 }
 
 // Validate validates the model against the schema.

--- a/src/pkg/validation/validator_test.go
+++ b/src/pkg/validation/validator_test.go
@@ -306,10 +306,7 @@ func TestValidator(t *testing.T) {
 	t.Run("IsLatestOscalVersion", func(t *testing.T) {
 		t.Parallel()
 
-		latestVersion, err := utils.GetLatestVersion()
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
+		latestVersion := utils.GetLatestSupportedVersion()
 
 		t.Run("returns false if the model is not the latest version of the OSCAL schema", func(t *testing.T) {
 			t.Parallel()

--- a/src/pkg/validation/validator_test.go
+++ b/src/pkg/validation/validator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
+	"github.com/defenseunicorns/go-oscal/src/internal/utils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -299,6 +300,55 @@ func TestValidator(t *testing.T) {
 			_, err = validator.GetValidationResult()
 			if err == nil {
 				t.Errorf("expected error, got %v", err)
+			}
+		})
+	})
+	t.Run("IsLatestOscalVersion", func(t *testing.T) {
+		t.Parallel()
+
+		latestVersion, err := utils.GetLatestVersion()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		t.Run("returns false if the model is not the latest version of the OSCAL schema", func(t *testing.T) {
+			t.Parallel()
+			validator, err := NewValidator(gooscaltest.ByteMap[gooscaltest.ValidComponentPath])
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			isLatest, err := validator.IsLatestOscalVersion()
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			if isLatest {
+				t.Errorf("expected false, got true")
+			}
+		})
+
+		t.Run("returns true if the model is the latest version of the OSCAL schema", func(t *testing.T) {
+			t.Parallel()
+			validator, err := NewValidator(gooscaltest.ByteMap[gooscaltest.ValidComponentPath])
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			jsonMap := validator.GetJsonModel()
+			jsonMap, err = utils.ReplaceOscalVersionInMap(jsonMap, latestVersion)
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+
+			validator, err = NewValidator(jsonMap)
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+
+			isLatest, err := validator.IsLatestOscalVersion()
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			if !isLatest {
+				t.Errorf("expected true, got false")
 			}
 		})
 	})


### PR DESCRIPTION
- Update utils/version.IsValidOscalVersion by extracting the regex check into validVersionFormat method
- created `GetLatestVersion` method that returns the `latestVersion` const. 
- Update `utils.VersionWarning` to return an error if there are any warnings. 
- Update `revise` and `validate` commands to handle printing the response from `VersionWarning`
- Remove `VersionWarning` call from the creation of a Validators
- Create `validator.IsLastestOscalVersion` that returns a `bool` or `error` if it fails to get the version from the oscal doc or the latest version. 
- update renovate.json w/ filepath and constant to update in utils/version. 
- create test to validate `GetLatestVersion` method against the update/oscal-version.yaml