### PR TITLE
150 release add workflow to create an update changelog pr after release

### DIFF
--- a/.github/workflows/update-changelog-post-release.yaml
+++ b/.github/workflows/update-changelog-post-release.yaml
@@ -1,0 +1,154 @@
+name: Create Changelog PR after release
+
+on:
+  release:
+    types: [published]
+jobs:
+  createIssue:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Create Changelog PR 
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const owner = "defenseunicorns";
+            const repo = "go-oscal";
+            const defaultRef = "heads/main";
+            const filePath = "CHANGELOG.md";
+            const unreleasedTitle = '## [unreleased] - yyyy-mm-dd';
+            const unreleasedUrlPrefix = `[unreleased]:`
+            const version = context.payload.release.tag_name;
+
+            // Get the formatted release date
+            const published_at = context.payload.release.published_at;
+            const date = published_at.split("T")[0];
+            
+            // Create the release title
+            const releaseTitle = `## [${version}] - ${date}`;
+
+            // Create the issue title and body
+            const issueTitle = `update changelog for ${repo} ${version}`;
+            const issueBody = `A new release of ${repo} has been published. Please review changes to the CHANGELOG.md and update accordingly.`;
+            
+            // search for an existing issue or create a new one if it doesn't exist
+            const {
+              data: { items: issues }
+            } = await github.rest.search.issuesAndPullRequests({
+              q: `${issueTitle} repo:${owner}/${repo} is:issue is:open in:title`
+            });
+        
+            // set the issue to the first issue found if it exists
+            // otherwise, create the issue
+            let issue;
+            if (issues.length > 0) {
+              issue = issues[0];
+            } else {
+              const res = await github.rest.issues.create({
+                owner: owner,
+                repo: repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['documentation']
+              });
+              issue = res.data;
+            }
+        
+            // create a branch title
+            const branchTitle = `${issue.number}-update-changelog-${version}`;
+        
+            // create a branch ref
+            const branchRef = `refs/heads/${branchTitle}`
+        
+            // get the default branch sha
+            const { data: { object: { sha: defaultSha } } } = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: defaultRef
+            });
+        
+            // try to create a new branch
+            try {
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: branchRef,
+                sha: defaultSha
+              });
+            } catch (error) {
+              // throw error if not branch already exists
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
+        
+            // get the branch changelog content
+            const { data: fileContents } = await github.rest.repos.getContent({
+              owner,
+              repo,
+              ref: branchRef,
+              path: filePath
+            });
+        
+            const content = Buffer.from(fileContents.content, 'base64').toString('utf-8');
+        
+            // if the content doesn't include the version and date, add it
+            if (!content.includes(`[${version}] - ${date}`)) {
+              const lines = content.split('\n');
+        
+              // Add the new version and date to the changelog
+              for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
+                // Add the new version and date to the changelog below the unreleased title
+                if (lines[lineNumber].startsWith(unreleasedTitle)) {
+                  lines.splice(lineNumber + 1, 0, releaseTitle);
+                  // Add a new line below the new version
+                  lines.splice(lineNumber + 1, 0, "")
+                } else if (lines[lineNumber].startsWith(unreleasedUrlPrefix)) {
+                  const lineContent = lines[lineNumber];
+                  // Update the unreleased compare line to point to the new version
+                  lines[lineNumber] = lineContent.replace(/unreleased/g, version).replace(/HEAD/g, version)
+                  // Add a new unreleased compare line above the new version
+                  lines.splice(lineNumber, 0, `[unreleased]: https://github.com/${owner}/${repo}/compare/${version}...HEAD`)
+                }
+              }
+              // Join the lines back together
+              const newContent = lines.join('\n');
+        
+              // push the new changelog content to the branch
+              await github.rest.repos.createOrUpdateFileContents({
+                owner,
+                repo,
+                path: filePath,
+                message: `update changelog for ${version} release`,
+                content: Buffer.from(newContent).toString('base64'),
+                branch: branchTitle,
+                sha: fileContents.sha
+              })
+            }
+        
+            // Try to create a new PR
+            try {
+              await github.rest.pulls.create({
+                owner,
+                repo,
+                issue: issue.number,
+                head: branchTitle,
+                base: 'main',
+              })
+            } catch (error) {
+              // ignore error if the PR already exists
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
+            
+              
+
+
+            

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# [unreleased] - yyyy-mm-dd
+## [unreleased] - yyyy-mm-dd
+
+### Fix
+- duplicate issues being created on OSCAL release to upgrade
+
+### Add
+- workflow to update the change log with version and date after release. 
+
+## [v0.2.1] - 2024-03-01
 
 ### Fix
 
-- utils/timestamp.GetTimeStamp now returns `time.Now()` as type `time.Time` in accordance with the changes to oscalTypes. 
-  - `time.Time` is marshalled and unmarshalled to rfc3339 by default in compliance with the oscal complete schema expected timestamp format. 
+- utils/timestamp.GetTimeStamp now returns `time.Now()` as type `time.Time` in accordance with the changes to `oscalTypes_*`. 
+  - `time.Time` is marshaled and un-marshaled to `RFC3339` by default in compliance with the OSCAL complete schema expected timestamp format. 
 
-# v0.2.0 - 2024-02-29
+## [v0.2.0] - 2024-02-29
 
 ### Added
 - OSCAL 1.1.2 types
@@ -136,3 +144,100 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - fix improper links to `Group` (should have been `AssemblyOscalProfileGroup` previously, now `CustomGroupingGroup`) in `CustomGrouping` (previously `Custom`) and `Merge` structs.
   
 - Fix `CustomGrouping.Groups` (previously `Custom.Groups`) to be of type `CustomGroupingGroup` as the definition differs from that of previously declared `Group struct`
+
+## [v0.1.0] - 2024-01-05
+note: Bumping minor release in order to create a clean release baseline. 
+
+## What's Changed
+* deps Update dependency go to v1.21.5 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/72
+* fix: CODEOWNER creation and dependabot removal by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/75
+* deps Update actions/setup-go action to v5 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/76
+* deps Update github/codeql-action action to v2.22.9 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/80
+* feat: OSCAL Version Tracking by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/81
+* fix!: renovate validator to update config by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/89
+* fix: updated release docs by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/85
+* #55. Create Command Tests by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/77
+* #93. Fix test_output.go beind dumped into the cmd/generate directory … by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/94
+* deps Update github/codeql-action action to v3 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/98
+* 33 upgrade transformupdate across model versions by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/97
+* deps Update module github.com/google/uuid to v1.5.0 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/96
+* deps Update actions/download-artifact action to v4 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/100
+* deps Update actions/upload-artifact action to v4 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/101
+* #102. Create UpdateLastModified method that is used when revising a p… by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/103
+* deps Update actions/download-artifact action to v4.1.0 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/104
+* deps Update github/codeql-action action to v3.22.12 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/105
+* deps Update anchore/sbom-action action to v0.15.2 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/106
+
+## [v0.0.2] - 2024-01-05
+
+## What's Changed
+* deps Update dependency go to v1.21.5 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/72
+* fix: CODEOWNER creation and dependabot removal by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/75
+* deps Update actions/setup-go action to v5 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/76
+* deps Update github/codeql-action action to v2.22.9 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/80
+* feat: OSCAL Version Tracking by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/81
+* fix!: renovate validator to update config by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/89
+* fix: updated release docs by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/85
+* #55. Create Command Tests by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/77
+* #93. Fix test_output.go beind dumped into the cmd/generate directory … by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/94
+* deps Update github/codeql-action action to v3 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/98
+* 33 upgrade transformupdate across model versions by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/97
+* deps Update module github.com/google/uuid to v1.5.0 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/96
+* deps Update actions/download-artifact action to v4 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/100
+* deps Update actions/upload-artifact action to v4 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/101
+* #102. Create UpdateLastModified method that is used when revising a p… by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/103
+* deps Update actions/download-artifact action to v4.1.0 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/104
+* deps Update github/codeql-action action to v3.22.12 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/105
+* deps Update anchore/sbom-action action to v0.15.2 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/106
+
+## [v0.0.1] - 2023-12-5
+
+## What's Changed
+* Add initial, experimental logic and notes about context and usage by @lucasrod16 in https://github.com/defenseunicorns/go-oscal/pull/1
+* Update --input flag to --input-file in readme by @lucasrod16 in https://github.com/defenseunicorns/go-oscal/pull/3
+* Updating Makefile for minor optimizations by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/6
+* Initial logic for generating map for struct creation by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/5
+* Code cleanup and update documentation by @lucasrod16 in https://github.com/defenseunicorns/go-oscal/pull/11
+* Add header comment to generated structs by @lucasrod16 in https://github.com/defenseunicorns/go-oscal/pull/14
+* Unit tests by @lucasrod16 in https://github.com/defenseunicorns/go-oscal/pull/15
+* Add top-level struct generation by @lucasrod16 in https://github.com/defenseunicorns/go-oscal/pull/17
+* Bump actions/setup-go from 3 to 4 by @dependabot in https://github.com/defenseunicorns/go-oscal/pull/22
+* Bump github.com/spf13/cobra from 1.6.1 to 1.7.0 by @dependabot in https://github.com/defenseunicorns/go-oscal/pull/23
+* Bump actions/checkout from 3 to 4 by @dependabot in https://github.com/defenseunicorns/go-oscal/pull/24
+* Oscal schema updates support by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/28
+* Test: additional models testing and explicit failure by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/31
+* Types Export for latest supported OSCAL models by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/32
+* Bump github.com/swaggest/jsonschema-go from 0.3.60 to 0.3.62 by @dependabot in https://github.com/defenseunicorns/go-oscal/pull/34
+* Feat: deterministic generation by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/36
+* Feat: generate command migration & convert command initial commit by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/38
+* Security assessment results by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/40
+* Initial commit for generation of all oscal models by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/47
+* Fix: add omitempty for marshall process by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/48
+* Feat: Add uuid generation functions for library use by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/51
+* 37 object validation for models by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/50
+* 53 validate better error messaging for failed validation by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/57
+* Feat: update ValidateCommand parameters to allow streamlined export by @brandtkeller in https://github.com/defenseunicorns/go-oscal/pull/59
+* feat: add norm vuln scanning and updating. by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/60
+* deps Update module github.com/spf13/cobra to v1.8.0 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/62
+* deps Update dependency go to v1.21.4 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/61
+* 53 validate better error messaging for failed validation by @mike-winberry in https://github.com/defenseunicorns/go-oscal/pull/67
+* deps Update module github.com/swaggest/jsonschema-go to v0.3.64 by @renovate in https://github.com/defenseunicorns/go-oscal/pull/66
+* feat: initial release process by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/71
+* fix!: added tool installs action to include syft by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/73
+* fix!: move the install to correct phase by @CloudBeard in https://github.com/defenseunicorns/go-oscal/pull/74
+
+## New Contributors
+* @lucasrod16 made their first contribution in https://github.com/defenseunicorns/go-oscal/pull/1
+* @brandtkeller made their first contribution in https://github.com/defenseunicorns/go-oscal/pull/6
+* @dependabot made their first contribution in https://github.com/defenseunicorns/go-oscal/pull/22
+* @mike-winberry made their first contribution in https://github.com/defenseunicorns/go-oscal/pull/50
+* @CloudBeard made their first contribution in https://github.com/defenseunicorns/go-oscal/pull/60
+* @renovate made their first contribution in https://github.com/defenseunicorns/go-oscal/pull/62
+
+
+[unreleased]: https://github.com/defenseunicorns/go-oscal/compare/v0.2.1...HEAD
+[v0.2.1]: https://github.com/defenseunicorns/go-oscal/compare/v0.2.0...v0.2.1
+[v0.2.0]: https://github.com/defenseunicorns/go-oscal/compare/v0.1.0...v0.2.0
+[v0.1.0]: https://github.com/defenseunicorns/go-oscal/compare/v0.0.2...v0.1.0
+[v0.0.2]: https://github.com/defenseunicorns/go-oscal/compare/v0.0.1...v0.0.2
+[v0.0.1]: https://github.com/defenseunicorns/go-oscal/releases/tag/v0.0.1

--- a/docs/updating-changelog.md
+++ b/docs/updating-changelog.md
@@ -1,0 +1,13 @@
+# Updating the changelog
+The changelog should be updated before merging and after a release. 
+
+
+## Before merge
+- changelog should be updated in accordance with [keep-a-changelog](https://keepachangelog.com/en/1.1.0/)
+- currently no automation see issue [#153](https://github.com/defenseunicorns/go-oscal/issues/153) if you would like to help. 
+
+## After release
+- After a release is published the workflow [update-changelog](../.github/workflows/update-changelog-post-release.yaml) will run and create a PR. 
+- This workflow handles adding the new `## [version] - yyyy-mm-dd` tag replacing the old `## [unreleased] - yyyy-mm-dd` subheader.
+- This workflow also handles updating the links with the compare to last version. 
+- Any additional changes to the changelog done at release should be added before merging. 


### PR DESCRIPTION
- Created workflow to update the changelog in accordance with keep-a-changelog after release.
- Updated the current changelog to be of correct formatting and added all releases. 
- Create docs/updating-changelog for information on updating the changelog. 

### Redirect:
- look into current tools like go-releaser to manage the changelog. 
- checkout other open source co-projects and handle in a similar method. 
- go-releaser behind paywall.
- Current OSS pattern does not include changelog for pepr, zarf, leapfrogai. 
- do we want to go with release-please flow? or scrap to follow suit with our other projects. 
- https://goreleaser.com/customization/changelog/