### PR TITLE
refactor: #160 revise and validatecommand methods to lift out the logging

### DIFF
--- a/src/cmd/revise/revise.go
+++ b/src/cmd/revise/revise.go
@@ -34,7 +34,7 @@ var ReviseCmd = &cobra.Command{
 	Long:  "Revise a given model from one oscal version to the specified oscal version. The steps to revise are output to log, successful revision is output to stdout or the specified output file.",
 	// Example: convertHelp,
 	RunE: func(cmd *cobra.Command, componentDefinitionPaths []string) error {
-		const OUTPUT_DEFAULT = "json"
+		var OUTPUT_DEFAULT = ".json"
 
 		// If output file is not specified, set it to json, so it will not throw an error and can be printed to stdout
 		if opts.OutputFile == "" {

--- a/src/cmd/revise/revise.go
+++ b/src/cmd/revise/revise.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var opts = &revision.ReviseOptions{}
+var opts = &revision.RevisionOptions{}
 
 var ReviseCmd = &cobra.Command{
 	Use:   "revise",

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type ValidationResponse struct {
+	Validator validation.Validator
+	Result    validation.ValidationResult
+	Warnings  []string
+}
+
 var inputfile string
 var validationResultFile string
 
@@ -20,64 +26,78 @@ var ValidateCmd = &cobra.Command{
 	Short: "validate an oscal document",
 	Long:  "Validate an OSCAL document against the OSCAL schema version specified in the document.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		validator, validationErr := ValidateCommand(inputfile)
+		validationResponse, validationErr := ValidateCommand(inputfile)
 
 		// Write validation result if it was specified and exists before returning ValidateCommand error
-		validationResult, err := validator.GetValidationResult()
-		if err == nil && validationResultFile != "" {
-			err = validation.WriteValidationResult(validationResult, validationResultFile)
+		if validationResultFile != "" {
+			err := validation.WriteValidationResult(validationResponse.Result, validationResultFile)
 			if err != nil {
 				log.Printf("Failed to write validation result to %s: %s\n", validationResultFile, err)
 			}
 		}
-
 		// Return the error from the validation if there was one
 		if validationErr != nil {
 			return validationErr
 		}
 
+		if len(validationResponse.Warnings) > 0 {
+			for _, warning := range validationResponse.Warnings {
+				log.Print(warning)
+			}
+		}
+
 		// No errors, log success
-		log.Printf("Successfully validated %s is valid OSCAL version %s %s\n", inputfile, validator.GetSchemaVersion(), validator.GetModelType())
+		log.Printf("Successfully validated %s is valid OSCAL version %s %s\n", inputfile, validationResponse.Validator.GetSchemaVersion(), validationResponse.Validator.GetModelType())
 		return nil
 	},
 }
 
-func ValidateCommand(inputFile string) (validator validation.Validator, err error) {
+func ValidateCommand(inputFile string) (validationResponse ValidationResponse, err error) {
 	// Validate the input file
 	if inputFile == "" {
-		return validator, errors.New("please specify an input file with the -f flag")
+		return validationResponse, errors.New("please specify an input file with the -f flag")
 	}
 
 	// Validate the input file is a json or yaml file
 	if !strings.HasSuffix(inputFile, "json") && !strings.HasSuffix(inputFile, "yaml") {
-		return validator, errors.New("please specify a json or yaml file")
+		return validationResponse, errors.New("please specify a json or yaml file")
 	}
 
 	// Read the input file
 	bytes, err := os.ReadFile(inputFile)
 	if err != nil {
-		return validator, fmt.Errorf("reading input file: %s", err)
+		return validationResponse, fmt.Errorf("reading input file: %s", err)
 	}
 
-	validator, err = validation.NewValidator(bytes)
+	validator, err := validation.NewValidator(bytes)
 	if err != nil {
-		return validator, fmt.Errorf("failed to create validator: %s", err)
+		return validationResponse, fmt.Errorf("failed to create validator: %s", err)
 	}
 
 	version := validator.GetSchemaVersion()
 	err = utils.VersionWarning(version)
 	if err != nil {
-		log.Print(err)
+		validationResponse.Warnings = append(validationResponse.Warnings, err.Error())
 	}
 
 	validator.SetDocumentPath(inputFile)
 
-	err = validator.Validate()
-	if err != nil {
-		return validator, fmt.Errorf("failed to validate %s version %s: %s", validator.GetModelType(), validator.GetSchemaVersion(), err)
+	validationError := validator.Validate()
+
+	// Write validation result if it was specified and exists before returning ValidateCommand error
+	validationResult, _ := validator.GetValidationResult()
+
+	validationResponse = ValidationResponse{
+		Validator: validator,
+		Result:    validationResult,
+		Warnings:  validationResponse.Warnings,
 	}
 
-	return validator, nil
+	if validationError != nil {
+		return validationResponse, fmt.Errorf("failed to validate %s version %s: %s", validator.GetModelType(), validator.GetSchemaVersion(), err)
+	}
+
+	return validationResponse, nil
 }
 
 func init() {

--- a/src/cmd/validate/validate.go
+++ b/src/cmd/validate/validate.go
@@ -52,6 +52,8 @@ var ValidateCmd = &cobra.Command{
 	},
 }
 
+// ValidateCommand validates an OSCAL document
+// Returns a ValidationResponse and an error
 func ValidateCommand(inputFile string) (validationResponse ValidationResponse, err error) {
 	// Validate the input file
 	if inputFile == "" {
@@ -69,30 +71,31 @@ func ValidateCommand(inputFile string) (validationResponse ValidationResponse, e
 		return validationResponse, fmt.Errorf("reading input file: %s", err)
 	}
 
+	// Create and set the validator in the validation response
 	validator, err := validation.NewValidator(bytes)
 	if err != nil {
 		return validationResponse, fmt.Errorf("failed to create validator: %s", err)
 	}
+	validationResponse.Validator = validator
 
+	// Get and set version warnings
 	version := validator.GetSchemaVersion()
 	err = utils.VersionWarning(version)
 	if err != nil {
 		validationResponse.Warnings = append(validationResponse.Warnings, err.Error())
 	}
 
+	// Set the document path
 	validator.SetDocumentPath(inputFile)
 
+	// Run the validation
 	validationError := validator.Validate()
 
 	// Write validation result if it was specified and exists before returning ValidateCommand error
 	validationResult, _ := validator.GetValidationResult()
+	validationResponse.Result = validationResult
 
-	validationResponse = ValidationResponse{
-		Validator: validator,
-		Result:    validationResult,
-		Warnings:  validationResponse.Warnings,
-	}
-
+	// Handle the validation error
 	if validationError != nil {
 		return validationResponse, fmt.Errorf("failed to validate %s version %s: %s", validator.GetModelType(), validator.GetSchemaVersion(), err)
 	}

--- a/src/pkg/revision/revision_command.go
+++ b/src/pkg/revision/revision_command.go
@@ -1,0 +1,87 @@
+package revision
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/defenseunicorns/go-oscal/src/pkg/utils"
+	"github.com/defenseunicorns/go-oscal/src/pkg/validation"
+)
+
+type RevisionResponse struct {
+	Reviser      Reviser
+	Result       validation.ValidationResult
+	Warnings     []string
+	RevisedBytes []byte
+}
+
+type ReviseOptions struct {
+	InputFile        string // filepath json or yaml
+	OutputFile       string // filepath json or yaml
+	Version          string // OSCAL version X.X.X
+	ValidationResult string // filepath json or yaml
+}
+
+// RevisionCommand Runs the revision and returns the revision response
+// For Consumers, this method assumes no ReviseOptions defaults. All defaults are handled in the cobra command.
+func RevisionCommand(opts *ReviseOptions) (revisionResponse RevisionResponse, err error) {
+	// Validate inputfile was provided and that is json or yaml
+	if err := utils.IsJsonOrYaml(opts.InputFile); err != nil {
+		return revisionResponse, fmt.Errorf("invalid input file: %s", err)
+	}
+
+	// If output file is not json or yaml, return an error
+	if err := utils.IsJsonOrYaml(opts.OutputFile); err != nil {
+		return revisionResponse, fmt.Errorf("invalid output file: %s", err)
+	}
+
+	// If version is not specified, return an error
+	if opts.Version == "" {
+		return revisionResponse, errors.New("please specify a version to convert to with the -v flag")
+	}
+
+	// Read the input file
+	bytes, err := os.ReadFile(opts.InputFile)
+	if err != nil {
+		return revisionResponse, fmt.Errorf("reading input file: %s", err)
+	}
+
+	// Create the reviser and set it in the response
+	reviser, err := NewReviser(bytes, opts.Version)
+	if err != nil {
+		return revisionResponse, fmt.Errorf("failed to create reviser: %s", err)
+	}
+	revisionResponse.Reviser = reviser
+
+	// Get the schema version and set warnings if they exist
+	version := reviser.GetSchemaVersion()
+	err = utils.VersionWarning(version)
+	if err != nil {
+		revisionResponse.Warnings = append(revisionResponse.Warnings, err.Error())
+	}
+
+	// Set the document path
+	reviser.SetDocumentPath(opts.InputFile)
+
+	// Run the revision
+	err = reviser.Revise()
+
+	// Get the validation result and set it in the response
+	validationResult, _ := reviser.GetValidationResult()
+	revisionResponse.Result = validationResult
+
+	// return the revision error if there was one
+	if err != nil {
+		return revisionResponse, fmt.Errorf("failed to upgrade %s version %s: %s", reviser.GetModelType(), reviser.GetSchemaVersion(), err)
+	}
+
+	// Get the upgraded bytes and set them in the response
+	revisedBytes, err := reviser.GetRevisedBytes(opts.OutputFile)
+	if err != nil {
+		return revisionResponse, fmt.Errorf("failed to get upgraded bytes: %s", err)
+	}
+	revisionResponse.RevisedBytes = revisedBytes
+
+	return revisionResponse, nil
+}

--- a/src/pkg/revision/revision_command.go
+++ b/src/pkg/revision/revision_command.go
@@ -16,7 +16,7 @@ type RevisionResponse struct {
 	RevisedBytes []byte
 }
 
-type ReviseOptions struct {
+type RevisionOptions struct {
 	InputFile        string // filepath json or yaml
 	OutputFile       string // filepath json or yaml
 	Version          string // OSCAL version X.X.X
@@ -25,7 +25,7 @@ type ReviseOptions struct {
 
 // RevisionCommand Runs the revision and returns the revision response
 // For Consumers, this method assumes no ReviseOptions defaults. All defaults are handled in the cobra command.
-func RevisionCommand(opts *ReviseOptions) (revisionResponse RevisionResponse, err error) {
+func RevisionCommand(opts *RevisionOptions) (revisionResponse RevisionResponse, err error) {
 	// Validate inputfile was provided and that is json or yaml
 	if err := utils.IsJsonOrYaml(opts.InputFile); err != nil {
 		return revisionResponse, fmt.Errorf("invalid input file: %s", err)

--- a/src/pkg/revision/revision_command_test.go
+++ b/src/pkg/revision/revision_command_test.go
@@ -13,7 +13,7 @@ func TestRevisionCommand(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns an error if no input file is provided", func(t *testing.T) {
-		opts := &revision.ReviseOptions{}
+		opts := &revision.RevisionOptions{}
 		_, err := revision.RevisionCommand(opts)
 		if err == nil {
 			t.Error("expected an error, got nil")
@@ -21,7 +21,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns an error if the input file is not json or yaml", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile: "invalid",
 		}
 		_, err := revision.RevisionCommand(opts)
@@ -31,7 +31,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns an error if the output file is not json or yaml", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile:  gooscaltest.ValidCatalogPath,
 			OutputFile: "invalid",
 		}
@@ -42,7 +42,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns an error if no version is provided", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile:  gooscaltest.ValidCatalogPath,
 			OutputFile: gooscaltest.ValidCatalogPath,
 		}
@@ -53,7 +53,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns an error if the input file is not found", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile:  "invalid.json",
 			OutputFile: gooscaltest.ValidCatalogPath,
 			Version:    "1.0.6",
@@ -65,7 +65,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns an error and ValidationResponse if the input file fails validation", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile:  gooscaltest.InvalidCatalogPath,
 			OutputFile: gooscaltest.ValidCatalogPath,
 			Version:    "1.0.6",
@@ -82,7 +82,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns a warning if the version is not the latest", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile:  gooscaltest.ValidCatalogPath,
 			OutputFile: gooscaltest.ValidCatalogPath,
 			Version:    "1.0.6",
@@ -99,7 +99,7 @@ func TestRevisionCommand(t *testing.T) {
 	})
 
 	t.Run("returns the upgraded bytes if the revision is successful", func(t *testing.T) {
-		opts := &revision.ReviseOptions{
+		opts := &revision.RevisionOptions{
 			InputFile:  gooscaltest.ValidCatalogPath,
 			OutputFile: gooscaltest.ValidCatalogPath,
 			Version:    "1.0.6",

--- a/src/pkg/revision/revision_command_test.go
+++ b/src/pkg/revision/revision_command_test.go
@@ -1,0 +1,117 @@
+package revision_test
+
+import (
+	"testing"
+
+	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
+	"github.com/defenseunicorns/go-oscal/src/pkg/revision"
+	"github.com/defenseunicorns/go-oscal/src/pkg/validation"
+)
+
+func TestRevisionCommand(t *testing.T) {
+	// TestRevisionCommand tests the revision command
+	t.Parallel()
+
+	t.Run("returns an error if no input file is provided", func(t *testing.T) {
+		opts := &revision.ReviseOptions{}
+		_, err := revision.RevisionCommand(opts)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error if the input file is not json or yaml", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile: "invalid",
+		}
+		_, err := revision.RevisionCommand(opts)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error if the output file is not json or yaml", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile:  gooscaltest.ValidCatalogPath,
+			OutputFile: "invalid",
+		}
+		_, err := revision.RevisionCommand(opts)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error if no version is provided", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile:  gooscaltest.ValidCatalogPath,
+			OutputFile: gooscaltest.ValidCatalogPath,
+		}
+		_, err := revision.RevisionCommand(opts)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error if the input file is not found", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile:  "invalid.json",
+			OutputFile: gooscaltest.ValidCatalogPath,
+			Version:    "1.0.6",
+		}
+		_, err := revision.RevisionCommand(opts)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error and ValidationResponse if the input file fails validation", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile:  gooscaltest.InvalidCatalogPath,
+			OutputFile: gooscaltest.ValidCatalogPath,
+			Version:    "1.0.6",
+		}
+		revisionResponse, err := revision.RevisionCommand(opts)
+
+		if revisionResponse.Result.TimeStamp == (validation.ValidationResult{}).TimeStamp {
+			t.Error("expected a validation response, got nil")
+		}
+
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns a warning if the version is not the latest", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile:  gooscaltest.ValidCatalogPath,
+			OutputFile: gooscaltest.ValidCatalogPath,
+			Version:    "1.0.6",
+		}
+		revisionResponse, err := revision.RevisionCommand(opts)
+
+		if len(revisionResponse.Warnings) == 0 {
+			t.Error("expected a warning, got none")
+		}
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("returns the upgraded bytes if the revision is successful", func(t *testing.T) {
+		opts := &revision.ReviseOptions{
+			InputFile:  gooscaltest.ValidCatalogPath,
+			OutputFile: gooscaltest.ValidCatalogPath,
+			Version:    "1.0.6",
+		}
+		revisionResponse, err := revision.RevisionCommand(opts)
+
+		if len(revisionResponse.RevisedBytes) == 0 {
+			t.Error("expected upgraded bytes, got none")
+		}
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/src/pkg/validation/validation_command.go
+++ b/src/pkg/validation/validation_command.go
@@ -1,0 +1,62 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/defenseunicorns/go-oscal/src/pkg/utils"
+)
+
+type ValidationResponse struct {
+	Validator Validator
+	Result    ValidationResult
+	Warnings  []string
+}
+
+// ValidationCommand validates an OSCAL document
+// Returns a ValidationResponse and an error
+func ValidationCommand(inputFile string) (validationResponse ValidationResponse, err error) {
+	// Validate the input file is a json or yaml file
+	if !strings.HasSuffix(inputFile, "json") && !strings.HasSuffix(inputFile, "yaml") {
+		return validationResponse, errors.New("please specify a json or yaml file")
+	}
+
+	// Read the input file
+	bytes, err := os.ReadFile(inputFile)
+	if err != nil {
+		return validationResponse, fmt.Errorf("reading input file: %s", err)
+	}
+
+	// Create and set the validator in the validation response
+	validator, err := NewValidator(bytes)
+	if err != nil {
+		return validationResponse, fmt.Errorf("failed to create validator: %s", err)
+	}
+	validationResponse.Validator = validator
+
+	// Get and set version warnings
+	version := validator.GetSchemaVersion()
+	err = utils.VersionWarning(version)
+	if err != nil {
+		validationResponse.Warnings = append(validationResponse.Warnings, err.Error())
+	}
+
+	// Set the document path
+	validator.SetDocumentPath(inputFile)
+
+	// Run the validation
+	validationError := validator.Validate()
+
+	// Write validation result if it was specified and exists before returning ValidateCommand error
+	validationResult, _ := validator.GetValidationResult()
+	validationResponse.Result = validationResult
+
+	// Handle the validation error
+	if validationError != nil {
+		return validationResponse, fmt.Errorf("failed to validate %s version %s: %s", validator.GetModelType(), validator.GetSchemaVersion(), err)
+	}
+
+	return validationResponse, nil
+}

--- a/src/pkg/validation/validation_command_test.go
+++ b/src/pkg/validation/validation_command_test.go
@@ -1,0 +1,66 @@
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/defenseunicorns/go-oscal/src/gooscaltest"
+	"github.com/defenseunicorns/go-oscal/src/pkg/validation"
+)
+
+func TestValidationCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns an error if no input file is provided", func(t *testing.T) {
+		_, err := validation.ValidationCommand("")
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error if the input file is not a json or yaml file", func(t *testing.T) {
+		_, err := validation.ValidationCommand("test.txt")
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns an error if the input file is not a valid oscal document", func(t *testing.T) {
+		_, err := validation.ValidationCommand("test.json")
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("returns a warning if the oscal version is not the latest", func(t *testing.T) {
+		validationResponse, err := validation.ValidationCommand(gooscaltest.ValidComponentPath)
+		if err != nil {
+			t.Error("expected an error, got nil")
+		}
+
+		if len(validationResponse.Warnings) == 0 {
+			t.Error("expected a warning, got none")
+		}
+	})
+
+	t.Run("returns a validation response if the input file is valid", func(t *testing.T) {
+		validationResponse, err := validation.ValidationCommand(gooscaltest.ValidComponentPath)
+		if err != nil {
+			t.Errorf("expected no error, got %s", err)
+		}
+
+		if validationResponse.Result.Valid != true {
+			t.Error("expected a valid result, got invalid")
+		}
+	})
+
+	t.Run("returns an error and validation result if the input file fails validation", func(t *testing.T) {
+		validationResponse, err := validation.ValidationCommand(gooscaltest.InvalidCatalogPath)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+
+		if validationResponse.Result.Valid != false {
+			t.Error("expected an invalid result, got valid")
+		}
+	})
+}


### PR DESCRIPTION
## Description
In order to better support consumption of the revise and validate logic, the `ValidateCommand` and `Revise`(-> RevisionCommand) has been refactored to handle returning a response object to allow for consumers to handle all messaging/logging and errors as they wish. The associated cobra commands have also been updated to support these changes and provide an example for consumers. 

- feat: create `RevisionResponse struct`
- feat: create `ValidationResponse struct`
- refactor!: `revise.Revise` -> `revise.RevisionCommand`
- refactor!: `ValidateCommand` renamed to `ValidationCommand`
- refactor!: `ValidationCommand` func now returns `ValidationResponse` instead of `validation.Validator`
- refactor!: `RevisionResponse` func now returns `RevisionResponse` instead of `revision.Reviser`
- refactor!: extract `ValidationCommand` and `ValidationResponse` into `pkg/validation/validation_command.go`
- refactor!: extract `RevisionCommand`, `RevisionOptions`, and `RevisionResponse` to `pkg/revision/revision_command.go`
- fix: `ReviseCmd` now properly sets the default version to the latest supported oscal version. 
 
## Related Issue
#160 #164 

## Type of change

- [x] Refactor (breaking)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed