### PR TITLE
fix: #167 yaml documents with trailing whitespace when using | or > are collapsed to quoted strings.

### DIFF
--- a/src/pkg/revision/revision_command.go
+++ b/src/pkg/revision/revision_command.go
@@ -47,6 +47,8 @@ func RevisionCommand(opts *RevisionOptions) (revisionResponse RevisionResponse, 
 		return revisionResponse, fmt.Errorf("reading input file: %s", err)
 	}
 
+	bytes = utils.RemoveTrailingWhitespace(bytes)
+
 	// Create the reviser and set it in the response
 	reviser, err := NewReviser(bytes, opts.Version)
 	if err != nil {

--- a/src/pkg/utils/files.go
+++ b/src/pkg/utils/files.go
@@ -7,6 +7,18 @@ import (
 	"strings"
 )
 
+// RemoveTrailingWhitespace removes trailing whitespace from each line in a byte array.
+// This is useful for removing trailing whitespace from a yaml file before it is marshalled into a struct.
+// Prevents strings from being collapsed into a single line by yaml parser.
+func RemoveTrailingWhitespace(bytes []byte) []byte {
+	str := string(bytes)
+	lines := strings.Split(str, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(l, " ")
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
 // WriteOutput writes to the provided output file or to stdout by default.
 func WriteOutput(output []byte, outputFile string) (err error) {
 	if outputFile == "" {

--- a/src/pkg/utils/files_test.go
+++ b/src/pkg/utils/files_test.go
@@ -7,6 +7,40 @@ import (
 	"github.com/defenseunicorns/go-oscal/src/pkg/utils"
 )
 
+func TestRemoveTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("It removes trailing whitespace from each line in a byte array", func(t *testing.T) {
+		t.Parallel()
+		testBytes := []byte("test  \n  test  \n")
+		expected := "test\n  test\n"
+		result := string(utils.RemoveTrailingWhitespace(testBytes))
+		if result != expected {
+			t.Error("expected", expected, "got", result)
+		}
+	})
+
+	t.Run("It returns the same byte array if there is no trailing whitespace", func(t *testing.T) {
+		t.Parallel()
+		testBytes := []byte("test\n  test\n")
+		expected := "test\n  test\n"
+		result := string(utils.RemoveTrailingWhitespace(testBytes))
+		if result != expected {
+			t.Error("expected", expected, "got", result)
+		}
+	})
+
+	t.Run("It does not remove leading whitespace", func(t *testing.T) {
+		t.Parallel()
+		testBytes := []byte("  test\n  test\n")
+		expected := "  test\n  test\n"
+		result := string(utils.RemoveTrailingWhitespace(testBytes))
+		if result != expected {
+			t.Error("expected", expected, "got", result)
+		}
+	})
+}
+
 func TestFileUtils(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description
This PR fixes issues when running revision on yaml documents that have trailing whitespace in strings that use the scalars | and >. When revision happens the yaml.v3 marshals and collapses those strings into single line quoted strings. By removing trailing whitespace from the lines of the document this is solved. 
...

## Related Issue
Fixes #167 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed