### PR TITLE
chore(release-please): #181 set release to draft

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,
             "release-type": "go",
+            "draft": true,
             "changelog-path": "CHANGELOG.md",
             "changelog-sections": [
                 {


### PR DESCRIPTION
## Description
Setting `draft: true` in release-please-config.json to be consistent with the draft setting in go-releaser. 

## Related Issue
#181

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed