### PR TITLE
fix(renovate.json): #195 changed 'deps' to 'deps:' for commitlint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     "gomodTidy"
   ],
   "commitBodyTable": true,
-  "commitMessagePrefix": "deps",
+  "commitMessagePrefix": "deps:",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Description
change `deps` to `deps:` in renovate.json for commitlint PR linting

## Related Issue
#195 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed