### PR TITLE
fix(deps): update renovate labels and pin release please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - name: Create release tag
         id: tag
-        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3

--- a/renovate.json
+++ b/renovate.json
@@ -49,5 +49,8 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "usnistgov/OSCAL"
     }
+  ],
+  "labels": [
+    "dependencies"
   ]
 }


### PR DESCRIPTION
## Description

Quick process updates - hotfix

Pin release please by version instead of digest
add `dependencies` label to renovate PR's (allows for tracking on the project board)

## Related Issue

No issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed