### PR TITLE
feat(types): add version constant to types 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BINDIR       := $(CURDIR)/bin
 BINNAME      ?= go-oscal
 INSTALL_PATH ?= /usr/local/bin
 # This should be replaced with the latest version of the OSCAL schema.
-OSCAL_LATEST ?= 1-1-1
+OSCAL_LATEST ?= 1-1-3
 # This should be replaced with the path to the latest oscal complete json schema associated with OSCAL_LATEST.
 UNDOCTORED_SCHEMA ?= testdata/doctor/oscal_complete_schema-1-1-1.json
 OSCAL_LATEST_SCHEMA := src/internal/schemas/oscal_complete_schema-$(OSCAL_LATEST).json
@@ -87,4 +87,4 @@ doctor-latest-schema: clean build
 
 .PHONY: generate-latest
 generate-latest-schema: clean build
-	$(BINDIR)/$(BINNAME) generate -f $(OSCAL_LATEST_SCHEMA) --pkg $(OSCAL_LATEST_PACKAGE) --tags json,yaml -o $(OSCAL_LATEST_OUTPUT)/types.go
+	$(BINDIR)/$(BINNAME) generate -f $(OSCAL_LATEST_SCHEMA) --pkg $(OSCAL_LATEST_PACKAGE) --tags json,yaml -o $(OSCAL_LATEST_OUTPUT)types.go

--- a/src/internal/generate/generate.go
+++ b/src/internal/generate/generate.go
@@ -73,7 +73,7 @@ func Generate(oscalSchema []byte, pkgName string, tags []string) (typeBytes []by
 		if err != nil {
 			return typeBytes, err
 		}
-		typeString += fmt.Sprintf("const OSCAL_VERSION = %s/n", version)
+		typeString += fmt.Sprintf("const Version = %q\n", version)
 	}
 
 	// Add the struct definitions in order of creation.

--- a/src/internal/generate/generate.go
+++ b/src/internal/generate/generate.go
@@ -66,6 +66,16 @@ func Generate(oscalSchema []byte, pkgName string, tags []string) (typeBytes []by
 	// Add additional imports
 	typeString += buildImportString()
 
+	// Parse the schema ID for the version reference
+	schemaId := schema.ID
+	if schemaId != nil {
+		version, err := extractVersion(*schemaId)
+		if err != nil {
+			return typeBytes, err
+		}
+		typeString += fmt.Sprintf("const OSCAL_VERSION = %s/n", version)
+	}
+
 	// Add the struct definitions in order of creation.
 	for _, ref := range config.refQueue.History() {
 		typeString += config.structMap[ref] + "\n\n"

--- a/src/internal/generate/generate_utils.go
+++ b/src/internal/generate/generate_utils.go
@@ -1,7 +1,9 @@
 package generate
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -401,4 +403,25 @@ func buildImportString() string {
 	}
 	imports += ")\n"
 	return imports
+}
+
+// extractVersion parses a URL/string and returns the first x.y.z version it finds.
+func extractVersion(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+
+	// Match MAJOR.MINOR.PATCH (e.g., 1.1.3)
+	re := regexp.MustCompile(`\b\d+\.\d+\.\d+\b`)
+
+	// Search the path first; fall back to the whole string just in case.
+	if m := re.FindString(u.Path); m != "" {
+		return m, nil
+	}
+	if m := re.FindString(raw); m != "" {
+		return m, nil
+	}
+
+	return "", errors.New("version not found")
 }

--- a/src/types/oscal-1-0-4/types.go
+++ b/src/types/oscal-1-0-4/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.0.4"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`

--- a/src/types/oscal-1-0-5/types.go
+++ b/src/types/oscal-1-0-5/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.0.5"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`

--- a/src/types/oscal-1-0-6/types.go
+++ b/src/types/oscal-1-0-6/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.0.6"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`

--- a/src/types/oscal-1-1-0/types.go
+++ b/src/types/oscal-1-1-0/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.1.0"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`

--- a/src/types/oscal-1-1-1/types.go
+++ b/src/types/oscal-1-1-1/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.1.1"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`

--- a/src/types/oscal-1-1-2/types.go
+++ b/src/types/oscal-1-1-2/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.1.2"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`

--- a/src/types/oscal-1-1-3/types.go
+++ b/src/types/oscal-1-1-3/types.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const Version = "1.1.3"
+
 type OscalModels = OscalCompleteSchema
 type OscalCompleteSchema struct {
 	AssessmentPlan            *AssessmentPlan            `json:"assessment-plan,omitempty" yaml:"assessment-plan,omitempty"`


### PR DESCRIPTION
## Description

This parses the schema `$id` and sets the version as a constant for use by consumers managing multiple versions. 

Types files were re-generated after the addition. 

## Related Issue

Fixes #146

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed