### PR TITLE
chore(owners): update codeowners to oss-dev

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,4 @@
-* @brandtkeller @meganwolf0
-
-# Privileged pipeline files
-/.github/ @brandtkeller @meganwolf0
-/.gitignore @brandtkeller @meganwolf0
-/.goreleaser.yml @brandtkeller @meganwolf0
+* @defenseunicorns/oss-dev
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
## Description

Updating codeowners to refer to a team instead of individuals (of which I am the sole applicable codeowner currently). 

## Related Issue

No related issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/go-oscal/blob/main/CONTRIBUTING.md) followed