### PR TITLE
fix: trigger title check on release-please PRs

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -26,12 +26,9 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Install commitlint
-        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
-
       - name: Lint PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo '{"extends":["@commitlint/config-conventional"]}' > commitlint.config.json
-          echo "$PR_TITLE" | npx commitlint --config commitlint.config.json
+          echo "$PR_TITLE" | npx --yes --package @commitlint/cli --package @commitlint/config-conventional commitlint --config commitlint.config.json

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,6 +1,9 @@
 name: PR Title Check
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
   pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize, edited]
@@ -8,6 +11,10 @@ on:
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: title-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   title_check:

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -33,5 +33,5 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo '{"extends":["@commitlint/config-conventional"]}' > /tmp/commitlint.config.json
-          echo "$PR_TITLE" | npx commitlint --config /tmp/commitlint.config.json
+          echo '{"extends":["@commitlint/config-conventional"]}' > commitlint.config.json
+          echo "$PR_TITLE" | npx commitlint --config commitlint.config.json

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,10 +1,9 @@
 name: PR Title Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
-    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    types: [milestoned, opened, reopened, synchronize, edit]
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read
@@ -13,24 +12,19 @@ permissions:
 jobs:
   title_check:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: commitlint
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-
+        with:
+          node-version: lts/*
 
       - name: Install commitlint
-        run: npm ci --only=dev
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
 
       - name: Lint PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx commitlint 
+        run: |
+          echo '{"extends":["@commitlint/config-conventional"]}' > /tmp/commitlint.config.json
+          echo "$PR_TITLE" | npx commitlint --config /tmp/commitlint.config.json

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -24,11 +24,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: lts/*
+          node-version: "22"
 
       - name: Lint PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo '{"extends":["@commitlint/config-conventional"]}' > commitlint.config.json
-          echo "$PR_TITLE" | npx --yes --package @commitlint/cli --package @commitlint/config-conventional commitlint --config commitlint.config.json
+          echo "$PR_TITLE" | npx --yes --package @commitlint/cli@21.0.1 --package @commitlint/config-conventional@21.0.1 commitlint --config commitlint.config.json


### PR DESCRIPTION
## Summary

- Switches `commitlint.yaml` from `pull_request` to `pull_request_target` so the title check fires automatically on release-please PRs (which are created via `GITHUB_TOKEN`, causing `pull_request` to never trigger)
- Removes the `actions/checkout` step entirely — the commitlint config is solely `@commitlint/config-conventional`, a standard npm package; packages are installed inline with a temp config written at runtime, eliminating the `pull_request_target` checkout attack vector
- Removes the `milestoned` workaround event type that required manual intervention
- Fixes `edit` → `edited` (the former is not a valid GitHub Actions event type and was silently ignored)
- Adds explicit `node-version: lts/*` to the `setup-node` step

Closes #295

## Security rationale

`pull_request_target` is safe here because:
1. No code from any branch is checked out or executed
2. Permissions remain `contents: read, pull-requests: read` (no write access)
3. The PR title is passed via `env:` and used only as `$PR_TITLE` in the shell command — not inline-interpolated

## Test plan

- [x] Open a PR against `main` — confirm "PR Title Check" workflow triggers
- [x] Edit the title of an open PR — confirm the workflow triggers (validates the `edited` fix)
- [x] Submit a PR with a non-conventional title (e.g. `random title`) — confirm the workflow fails
- [x] Submit a PR with a valid conventional title (e.g. `fix: correct something`) — confirm the workflow passes
- [ ] After merge: confirm the next release-please PR update triggers the workflow without manual intervention